### PR TITLE
chore: ignore beads interactions log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ repomix-output.xml
 .dolt/
 *.db
 .beads/issues.jsonl
+.beads/interactions.jsonl


### PR DESCRIPTION
## Summary
- ignore 
- stop tracking the existing Beads interaction log

## Testing
- git check-ignore -v .beads/interactions.jsonl
- git status --short