### PR TITLE
[codex] Update inverter support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Tested:
 - Renogy Wanderer
 - Renogy DC-DC Charger
 - Renogy Smart Shunt 300
+- Renogy inverters advertising `RNGRIU*`
 
 Should work, but untested:
 
 - Renogy Adventurer
-- Renogy inverters advertising `RNGRIU*`
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 This custom Home Assistant integration provides monitoring capabilities for
 Renogy devices over Bluetooth Low Energy (BLE). Charge controllers and DCC
-chargers use BT-1 or BT-2 modules; Smart Shunt 300 devices advertise directly
-over BLE as `RTMShunt300*`.
+chargers use BT-1 or BT-2 modules; Renogy inverters advertise directly over BLE
+as `RNGRIU*`; Smart Shunt 300 devices advertise directly over BLE as
+`RTMShunt300*`.
 
 > **Disclaimer:** This integration is experimental software. Use caution when controlling electrical loads, and ensure any connected equipment is properly rated and protected.
 
@@ -24,14 +25,17 @@ Tested:
 Should work, but untested:
 
 - Renogy Adventurer
+- Renogy inverters advertising `RNGRIU*`
 
 ## Features
 
 - Automatic discovery of Renogy BLE devices
+- Automatic discovery of Renogy inverter devices advertising `RNGRIU*`
 - Automatic discovery of Smart Shunt 300 devices advertising `RTMShunt300*`
 - Monitor battery status (voltage, current, temperature, charge state)
 - Monitor solar panel (PV) performance metrics
 - Monitor load status and statistics
+- Monitor inverter AC output, frequency, load power, temperature, and diagnostic metadata
 - Monitor Smart Shunt voltage, current, power, state of charge, and derived energy
 - Turn the DC load output on/off (supported controllers only)
 - Monitor controller information
@@ -52,6 +56,7 @@ _Includes Amazon affiliate links which provide a small commission to support thi
 
 - Compatible Renogy device (see above)
   - Charge controllers and DCC chargers require a [BT-1](https://amzn.to/4pq4csm) or [BT-2](https://amzn.to/4iTNSO8) Bluetooth module.
+  - Renogy inverters advertise directly over BLE as `RNGRIU*`.
   - Smart Shunt 300 devices use their built-in BLE radio and do not require a BT-1 or BT-2 dongle.
   - Make sure to purchase the correct module for your device. Different devices use different ports.
 - Bluetooth radio for Home Assistant
@@ -108,6 +113,19 @@ The integration provides the following sensor groups:
 - Power Consumption
 - Daily Usage
 
+### Inverter Sensors
+
+- Battery Voltage
+- AC Output Voltage
+- AC Output Current
+- AC Output Frequency
+- Input Frequency
+- Load Active Power
+- Load Apparent Power
+- Temperature
+- Device ID
+- Model
+
 ### DC Load Control
 
 Some Renogy charge controllers expose a controllable DC load output. This integration creates a `switch` entity that can turn the DC load on or off.
@@ -148,10 +166,11 @@ It can be extremely helpful to enable debug logging when troubleshooting issues.
 
 1. Verify the device is supported by this integration
 2. For controllers or DCC chargers, confirm a BT-1 or BT-2 module is installed
-3. For Smart Shunt 300 devices, confirm the BLE name starts with `RTMShunt300`
-4. Check that Bluetooth is enabled on your Home Assistant host
-5. Ensure the device is within range (typically 10m/33ft)
-6. Restart the Bluetooth adapter
+3. For inverter devices, confirm the BLE name starts with `RNGRIU`
+4. For Smart Shunt 300 devices, confirm the BLE name starts with `RTMShunt300`
+5. Check that Bluetooth is enabled on your Home Assistant host
+6. Ensure the device is within range (typically 10m/33ft)
+7. Restart the Bluetooth adapter
 
 ### Connection Issues
 

--- a/docs/planning/spec.md
+++ b/docs/planning/spec.md
@@ -1,20 +1,26 @@
-# Renogy Rover BLE Integration Specification for Home Assistant
+# Renogy BLE Integration Specification for Home Assistant
 
 ## Overview
 
-This document outlines the detailed requirements, architecture, data handling, error management strategies, and testing plan for a Home Assistant integration supporting Renogy Rover charge controllers via Bluetooth (BLE), specifically with BT-1 and BT-2 modules. The integration leverages the existing `renogy-ble` Python parsing library.
+This document outlines the detailed requirements, architecture, data handling,
+error management strategies, and testing plan for a Home Assistant integration
+supporting Renogy BLE devices. The integration leverages the existing
+`renogy-ble` Python library for BLE communication and parsing.
 
 ---
 
 ## 1. Functional Requirements
 
 ### 1.1 Supported Devices
-- Initially support **Renogy Rover charge controllers** (BT-1 and BT-2 modules)
-- Expandable to support other models later
+- Supports **Renogy charge controllers** using BT-1 and BT-2 modules
+- Supports **Renogy DC-DC chargers**
+- Supports **Renogy inverters** advertising `RNGRIU*`
+- Supports **Renogy Smart Shunt 300** devices advertising `RTMShunt300*`
 
 ### 1.2 Sensor Exposure
 
-All sensors from the provided `REGISTER_MAP` will be exposed clearly as Home Assistant entities:
+Supported telemetry from `renogy-ble` will be exposed clearly as Home Assistant
+entities for each supported device type:
 
 ### Battery Sensors
 - Battery Voltage (`V`, scaled ×0.1)
@@ -52,6 +58,26 @@ All sensors from the provided `REGISTER_MAP` will be exposed clearly as Home Ass
 - Power Generation Today (`Wh`, daily cumulative)
 - Power Generation Total (`kWh`, cumulative)
 
+### Inverter Sensors
+- Battery Voltage (`V`)
+- AC Output Voltage (`V`)
+- AC Output Current (`A`)
+- AC Output Frequency (`Hz`)
+- Input Frequency (`Hz`)
+- Load Active Power (`W`)
+- Load Apparent Power (`VA`)
+- Temperature (`°C`)
+- Device ID (text)
+- Model (text)
+
+### Smart Shunt Sensors
+- Shunt Voltage (`V`)
+- Shunt Current (`A`)
+- Shunt Power (`W`)
+- Shunt State of Charge (`%`)
+- Shunt Charge Status (text)
+- Shunt Energy (derived totals)
+
 ## Architecture
 
 ### BLE Communication
@@ -59,9 +85,9 @@ All sensors from the provided `REGISTER_MAP` will be exposed clearly as Home Ass
 - Polling interval default: **60 seconds**, user-configurable between **10–600 seconds**.
 
 ### Device Discovery and Setup
-- Home Assistant automatically discovers Renogy Rover devices within BLE range.
+- Home Assistant automatically discovers supported Renogy BLE devices within BLE range.
 - Discovered devices appear in the Home Assistant UI for easy setup.
-- Device names default to their unique Bluetooth identifiers (e.g., `BT-TH-7724620D`).
+- Device names default to their Bluetooth identifiers (for example `BT-TH-7724620D`, `RNGRIU123456`, or `RTMShunt300A1B2`).
 - Device metadata (manufacturer, model, firmware version, serial/device ID) stored as device-level attributes in Home Assistant.
 
 ### Entity Organization
@@ -70,6 +96,8 @@ Sensors automatically grouped logically in Home Assistant:
 - **Solar Panel (PV)**
 - **Load**
 - **Controller Info**
+- **Inverter**
+- **Shunt**
 
 ## Data Handling
 
@@ -109,7 +137,7 @@ Sensors automatically grouped logically in Home Assistant:
 - Minimal README-style documentation for initial release:
   - Brief integration description
   - Setup and installation instructions via HACS
-  - Required hardware clearly stated (Renogy Rover devices with BT-1/BT-2, Bluetooth adapter)
+  - Required hardware clearly stated for controller, DCC, inverter, and shunt devices
 
 ## Licensing
 - Integration code licensed under **Apache License 2.0**, matching existing parsing library.
@@ -122,4 +150,3 @@ Sensors automatically grouped logically in Home Assistant:
 ---
 
 This specification provides all the necessary information and guidelines to begin immediate implementation of the Renogy Rover BLE integration for Home Assistant.
-


### PR DESCRIPTION
## Summary
This updates the Home Assistant integration documentation to match the existing inverter support already present in the codebase.

## What changed
- added inverter support details to the top-level README
- documented `RNGRIU*` inverter discovery behavior
- added the inverter sensor set to the README
- updated the planning spec so it no longer describes a controller-only scope

## Why
The implementation already supports inverters, but the docs still described older support boundaries and made the feature look absent.

## Validation
- reviewed the code paths and existing tests that already cover inverter support
- ran `git diff --check`
