### PR TITLE
[codex] Expose Renogy battery devices

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -399,6 +399,9 @@ class RenogyActiveBluetoothCoordinator(
     ) -> RenogyBLEDevice:
         """Ensure the device instance is updated from Bluetooth service info."""
         manufacturer_data = getattr(service_info.advertisement, "manufacturer_data", {})
+        if not manufacturer_data and self.device is not None:
+            # Some follow-up advertisements omit manufacturer data entirely.
+            manufacturer_data = self.device.manufacturer_data
         detected_type = detect_device_type_from_ble_name(
             service_info.name,
             self.device_type,

--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -398,8 +398,11 @@ class RenogyActiveBluetoothCoordinator(
         self, service_info: BluetoothServiceInfoBleak
     ) -> RenogyBLEDevice:
         """Ensure the device instance is updated from Bluetooth service info."""
+        manufacturer_data = getattr(service_info.advertisement, "manufacturer_data", {})
         detected_type = detect_device_type_from_ble_name(
-            service_info.name, self.device_type
+            service_info.name,
+            self.device_type,
+            manufacturer_data=manufacturer_data,
         )
         if self.device_type != detected_type:
             self.logger.debug(
@@ -419,10 +422,12 @@ class RenogyActiveBluetoothCoordinator(
                 service_info.device,
                 service_info.advertisement.rssi,
                 device_type=detected_type,
+                manufacturer_data=manufacturer_data,
             )
         else:
             old_name = self.device.name
             self.device.ble_device = service_info.device
+            self.device.manufacturer_data = dict(manufacturer_data)
             if has_real_device_name(service_info.name):
                 cleaned_name = clean_device_name(service_info.name)
                 if old_name != cleaned_name:

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -35,7 +35,13 @@ from .const import (
     SUPPORTED_DEVICE_TYPES,
     DeviceType,
 )
-from .device_name import detect_device_type_from_ble_name, is_supported_renogy_ble_name
+from .device_name import (
+    detect_device_type_from_ble_name,
+    has_real_device_name,
+    is_supported_renogy_ble_name,
+)
+
+UNKNOWN_DEVICE_NAME = "Unknown Renogy Device"
 
 # Common schema fields for device configuration
 DEVICE_TYPE_SCHEMA = {
@@ -51,6 +57,14 @@ SCAN_INTERVAL_SCHEMA = {
 
 # Base configuration schema without device selection
 CONFIG_SCHEMA = vol.Schema({**DEVICE_TYPE_SCHEMA, **SCAN_INTERVAL_SCHEMA})
+
+
+def _display_name_for_discovery(discovery_info: BluetoothServiceInfoBleak) -> str:
+    """Return a stable display name for a discovered BLE device."""
+    if has_real_device_name(discovery_info.name):
+        return discovery_info.name
+
+    return UNKNOWN_DEVICE_NAME
 
 
 def _build_shunt_options_schema(default_mode: str) -> vol.Schema:
@@ -116,6 +130,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
             discovery_info.name,
             discovery_info.address,
         )
+        discovery_name = _display_name_for_discovery(discovery_info)
 
         # Set unique ID and check if already configured
         await self.async_set_unique_id(discovery_info.address)
@@ -134,7 +149,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Set title to user-readable name
         self.context["title_placeholders"] = {
-            "name": discovery_info.name,
+            "name": discovery_name,
             "address": discovery_info.address,
         }
 
@@ -168,7 +183,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # Create a config entry
                 return self.async_create_entry(
-                    title=self._discovered_device.name,
+                    title=_display_name_for_discovery(self._discovered_device),
                     data=user_input,
                 )
             elif CONF_ADDRESS in user_input:
@@ -180,7 +195,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
-                    title=discovery_info.name,
+                    title=_display_name_for_discovery(discovery_info),
                     data=user_input,
                 )
 
@@ -199,7 +214,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 step_id="user",
                 data_schema=discovered_schema,
                 description_placeholders={
-                    "device_name": self._discovered_device.name,
+                    "device_name": _display_name_for_discovery(self._discovered_device),
                     "default_interval": str(DEFAULT_SCAN_INTERVAL),
                 },
                 errors=errors,
@@ -216,7 +231,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_ADDRESS): vol.In(
                     {
-                        address: f"{info.name} ({address})"
+                        address: (f"{_display_name_for_discovery(info)} ({address})")
                         for address, info in self._discovered_devices.items()
                     }
                 ),

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -67,6 +67,16 @@ def _display_name_for_discovery(discovery_info: BluetoothServiceInfoBleak) -> st
     return UNKNOWN_DEVICE_NAME
 
 
+def _detect_device_type_for_discovery(discovery_info: BluetoothServiceInfoBleak) -> str:
+    """Detect the device type for a bluetooth discovery record."""
+    manufacturer_data = getattr(discovery_info.advertisement, "manufacturer_data", {})
+    return detect_device_type_from_ble_name(
+        discovery_info.name,
+        DEFAULT_DEVICE_TYPE,
+        manufacturer_data=manufacturer_data,
+    )
+
+
 def _build_shunt_options_schema(default_mode: str) -> vol.Schema:
     """Build the Smart Shunt options schema."""
     return vol.Schema(
@@ -138,14 +148,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Store the discovered device for later
         self._discovered_device = discovery_info
-        manufacturer_data = getattr(
-            discovery_info.advertisement, "manufacturer_data", {}
-        )
-        self._default_device_type = detect_device_type_from_ble_name(
-            discovery_info.name,
-            DEFAULT_DEVICE_TYPE,
-            manufacturer_data=manufacturer_data,
-        )
+        self._default_device_type = _detect_device_type_for_discovery(discovery_info)
 
         # Set title to user-readable name
         self.context["title_placeholders"] = {
@@ -190,6 +193,12 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Manual device selection
                 address = user_input[CONF_ADDRESS]
                 discovery_info = self._discovered_devices[address]
+                detected_type = _detect_device_type_for_discovery(discovery_info)
+
+                # Preserve an explicit user override, but fix the unchanged default
+                # when discovery data identifies a non-controller device.
+                if user_input.get(CONF_DEVICE_TYPE) == DEFAULT_DEVICE_TYPE:
+                    user_input[CONF_DEVICE_TYPE] = detected_type
 
                 await self.async_set_unique_id(address, raise_on_progress=False)
                 self._abort_if_unique_id_configured()

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -95,7 +95,11 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def _is_renogy_device(self, discovery_info: BluetoothServiceInfoBleak) -> bool:
         """Check if a BLE device advertises a supported Renogy name."""
-        return is_supported_renogy_ble_name(discovery_info.name)
+        manufacturer_data = getattr(discovery_info.advertisement, "manufacturer_data", {})
+        return is_supported_renogy_ble_name(
+            discovery_info.name,
+            manufacturer_data=manufacturer_data,
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -117,8 +121,11 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Store the discovered device for later
         self._discovered_device = discovery_info
+        manufacturer_data = getattr(discovery_info.advertisement, "manufacturer_data", {})
         self._default_device_type = detect_device_type_from_ble_name(
-            discovery_info.name, DEFAULT_DEVICE_TYPE
+            discovery_info.name,
+            DEFAULT_DEVICE_TYPE,
+            manufacturer_data=manufacturer_data,
         )
 
         # Set title to user-readable name

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -95,7 +95,9 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def _is_renogy_device(self, discovery_info: BluetoothServiceInfoBleak) -> bool:
         """Check if a BLE device advertises a supported Renogy name."""
-        manufacturer_data = getattr(discovery_info.advertisement, "manufacturer_data", {})
+        manufacturer_data = getattr(
+            discovery_info.advertisement, "manufacturer_data", {}
+        )
         return is_supported_renogy_ble_name(
             discovery_info.name,
             manufacturer_data=manufacturer_data,
@@ -121,7 +123,9 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Store the discovered device for later
         self._discovered_device = discovery_info
-        manufacturer_data = getattr(discovery_info.advertisement, "manufacturer_data", {})
+        manufacturer_data = getattr(
+            discovery_info.advertisement, "manufacturer_data", {}
+        )
         self._default_device_type = detect_device_type_from_ble_name(
             discovery_info.name,
             DEFAULT_DEVICE_TYPE,

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -15,6 +15,7 @@ MAX_SCAN_INTERVAL = 600  # seconds
 # Renogy BT-1 and BT-2 module identifiers - devices advertise with these prefixes
 RENOGY_BT_PREFIX = "BT-TH-"
 RENOGY_INVERTER_PREFIX = "RNGRIU"
+RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC")
 
 # Configuration parameters
 CONF_SCAN_INTERVAL = "scan_interval"
@@ -64,6 +65,7 @@ DEFAULT_NON_SHUNT_CONNECTION_MODE = NonShuntConnectionMode.INTERMITTENT.value
 # List of fully supported device types
 SUPPORTED_DEVICE_TYPES = [
     DeviceType.CONTROLLER.value,
+    DeviceType.BATTERY.value,
     DeviceType.DCC.value,
     DeviceType.INVERTER.value,
     DeviceType.SHUNT300.value,

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -12,6 +12,8 @@ from .const import (
 
 UNKNOWN_DEVICE_NAME_PREFIX = "Unknown"
 SHUNT300_BT_PREFIX = "RTMShunt300"
+BATTERY_LEGACY_NAME_MARKERS = ("BATT", "BATTERY")
+BATTERY_PRO_MANUFACTURER_ID = 0xE14C
 
 DEVICE_NAME_PREFIXES_BY_TYPE: dict[str, tuple[str, ...]] = {
     DeviceType.CONTROLLER.value: (RENOGY_BT_PREFIX,),
@@ -45,26 +47,62 @@ def is_device_name_ready(device_name: str | None, device_type: str) -> bool:
     """Return True when a name is present and matches the expected prefix."""
     if not isinstance(device_name, str) or not has_real_device_name(device_name):
         return False
+    if device_type == DeviceType.BATTERY.value and _is_legacy_battery_name(device_name):
+        return True
     return device_name.startswith(expected_prefixes_for_device_type(device_type))
 
 
-def is_supported_renogy_ble_name(device_name: str | None) -> bool:
-    """Return True for BLE names advertised by supported Renogy devices."""
-    if not isinstance(device_name, str) or not has_real_device_name(device_name):
-        return False
-    return any(device_name.startswith(prefix) for prefix in SUPPORTED_BLE_NAME_PREFIXES)
+def is_supported_renogy_ble_name(
+    device_name: str | None,
+    manufacturer_data: dict[int, bytes] | None = None,
+) -> bool:
+    """Return True for BLE advertisements from supported Renogy devices."""
+    return (
+        detect_device_type_from_ble_name(
+            device_name,
+            manufacturer_data=manufacturer_data,
+        )
+        != DEFAULT_DEVICE_TYPE
+        or _is_supported_default_type_name(device_name)
+    )
 
 
 def detect_device_type_from_ble_name(
-    device_name: str | None, default_device_type: str = DEFAULT_DEVICE_TYPE
+    device_name: str | None,
+    default_device_type: str = DEFAULT_DEVICE_TYPE,
+    manufacturer_data: dict[int, bytes] | None = None,
 ) -> str:
     """Infer the device type from a BLE name, with a provided default fallback."""
-    if not isinstance(device_name, str) or not has_real_device_name(device_name):
-        return default_device_type
-    if device_name.startswith(RENOGY_INVERTER_PREFIX):
-        return DeviceType.INVERTER.value
-    if device_name.startswith(RENOGY_BATTERY_PRO_PREFIXES):
+    manufacturer_data = manufacturer_data or {}
+
+    if isinstance(device_name, str) and has_real_device_name(device_name):
+        if device_name.startswith(RENOGY_INVERTER_PREFIX):
+            return DeviceType.INVERTER.value
+        if device_name.startswith(RENOGY_BATTERY_PRO_PREFIXES):
+            return DeviceType.BATTERY.value
+        if _is_legacy_battery_name(device_name):
+            return DeviceType.BATTERY.value
+        if device_name.startswith(SHUNT300_BT_PREFIX):
+            return DeviceType.SHUNT300.value
+
+    if BATTERY_PRO_MANUFACTURER_ID in manufacturer_data:
         return DeviceType.BATTERY.value
-    if device_name.startswith(SHUNT300_BT_PREFIX):
-        return DeviceType.SHUNT300.value
+
     return default_device_type
+
+
+def _is_legacy_battery_name(device_name: str) -> bool:
+    """Return True for legacy battery names and not generic BT-TH devices."""
+    if not device_name.startswith(RENOGY_BT_PREFIX):
+        return False
+
+    suffix = device_name[len(RENOGY_BT_PREFIX) :].upper()
+    return any(marker in suffix for marker in BATTERY_LEGACY_NAME_MARKERS)
+
+
+def _is_supported_default_type_name(device_name: str | None) -> bool:
+    """Return True for supported names that intentionally map to controller/DCC."""
+    if not isinstance(device_name, str) or not has_real_device_name(device_name):
+        return False
+
+    return any(device_name.startswith(prefix) for prefix in SUPPORTED_BLE_NAME_PREFIXES)

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .const import (
     DEFAULT_DEVICE_TYPE,
+    RENOGY_BATTERY_PRO_PREFIXES,
     RENOGY_BT_PREFIX,
     RENOGY_INVERTER_PREFIX,
     DeviceType,
@@ -12,17 +13,18 @@ from .const import (
 UNKNOWN_DEVICE_NAME_PREFIX = "Unknown"
 SHUNT300_BT_PREFIX = "RTMShunt300"
 
-DEVICE_NAME_PREFIX_BY_TYPE: dict[str, str] = {
-    DeviceType.CONTROLLER.value: RENOGY_BT_PREFIX,
-    DeviceType.BATTERY.value: RENOGY_BT_PREFIX,
-    DeviceType.INVERTER.value: RENOGY_INVERTER_PREFIX,
-    DeviceType.DCC.value: RENOGY_BT_PREFIX,
-    DeviceType.SHUNT300.value: SHUNT300_BT_PREFIX,
+DEVICE_NAME_PREFIXES_BY_TYPE: dict[str, tuple[str, ...]] = {
+    DeviceType.CONTROLLER.value: (RENOGY_BT_PREFIX,),
+    DeviceType.BATTERY.value: (RENOGY_BT_PREFIX, *RENOGY_BATTERY_PRO_PREFIXES),
+    DeviceType.INVERTER.value: (RENOGY_INVERTER_PREFIX,),
+    DeviceType.DCC.value: (RENOGY_BT_PREFIX,),
+    DeviceType.SHUNT300.value: (SHUNT300_BT_PREFIX,),
 }
 
 SUPPORTED_BLE_NAME_PREFIXES: tuple[str, ...] = (
     RENOGY_BT_PREFIX,
     RENOGY_INVERTER_PREFIX,
+    *RENOGY_BATTERY_PRO_PREFIXES,
     SHUNT300_BT_PREFIX,
 )
 
@@ -34,16 +36,16 @@ def has_real_device_name(device_name: str | None) -> bool:
     return bool(device_name) and not device_name.startswith(UNKNOWN_DEVICE_NAME_PREFIX)
 
 
-def expected_prefix_for_device_type(device_type: str) -> str:
-    """Return the expected BLE name prefix for a device type."""
-    return DEVICE_NAME_PREFIX_BY_TYPE.get(device_type, RENOGY_BT_PREFIX)
+def expected_prefixes_for_device_type(device_type: str) -> tuple[str, ...]:
+    """Return the expected BLE name prefixes for a device type."""
+    return DEVICE_NAME_PREFIXES_BY_TYPE.get(device_type, (RENOGY_BT_PREFIX,))
 
 
 def is_device_name_ready(device_name: str | None, device_type: str) -> bool:
     """Return True when a name is present and matches the expected prefix."""
     if not isinstance(device_name, str) or not has_real_device_name(device_name):
         return False
-    return device_name.startswith(expected_prefix_for_device_type(device_type))
+    return device_name.startswith(expected_prefixes_for_device_type(device_type))
 
 
 def is_supported_renogy_ble_name(device_name: str | None) -> bool:
@@ -61,6 +63,8 @@ def detect_device_type_from_ble_name(
         return default_device_type
     if device_name.startswith(RENOGY_INVERTER_PREFIX):
         return DeviceType.INVERTER.value
+    if device_name.startswith(RENOGY_BATTERY_PRO_PREFIXES):
+        return DeviceType.BATTERY.value
     if device_name.startswith(SHUNT300_BT_PREFIX):
         return DeviceType.SHUNT300.value
     return default_device_type

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -57,14 +57,10 @@ def is_supported_renogy_ble_name(
     manufacturer_data: dict[int, bytes] | None = None,
 ) -> bool:
     """Return True for BLE advertisements from supported Renogy devices."""
-    return (
-        detect_device_type_from_ble_name(
-            device_name,
-            manufacturer_data=manufacturer_data,
-        )
-        != DEFAULT_DEVICE_TYPE
-        or _is_supported_default_type_name(device_name)
-    )
+    return detect_device_type_from_ble_name(
+        device_name,
+        manufacturer_data=manufacturer_data,
+    ) != DEFAULT_DEVICE_TYPE or _is_supported_default_type_name(device_name)
 
 
 def detect_device_type_from_ble_name(

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -6,6 +6,12 @@
       "local_name": "BT-TH-*"
     },
     {
+      "local_name": "RNGRBP*"
+    },
+    {
+      "local_name": "RNGC*"
+    },
+    {
       "local_name": "RTMShunt300*"
     },
     {

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -6,6 +6,9 @@
       "local_name": "BT-TH-*"
     },
     {
+      "manufacturer_id": 57676
+    },
+    {
       "local_name": "RNGRBP*"
     },
     {

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -32,7 +32,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.2.2"
+    "renogy-ble==2.3.0"
   ],
   "version": "0.6.0"
 }

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -118,6 +118,16 @@ KEY_INPUT_FREQUENCY = "input_frequency"
 KEY_LOAD_ACTIVE_POWER = "load_active_power"
 KEY_LOAD_APPARENT_POWER = "load_apparent_power"
 KEY_TEMPERATURE = "temperature"
+KEY_BATTERY_CAPACITY = "battery_capacity"
+KEY_BATTERY_REMAINING_CAPACITY = "battery_remaining_capacity"
+KEY_BATTERY_POWER = "battery_power"
+KEY_BATTERY_CYCLE_COUNT = "battery_cycle_count"
+KEY_CELL_COUNT = "cell_count"
+KEY_CELL_VOLTAGE_MIN = "cell_voltage_min"
+KEY_CELL_VOLTAGE_MAX = "cell_voltage_max"
+KEY_CELL_VOLTAGE_DELTA = "cell_voltage_delta"
+KEY_BATTERY_PROBLEM_CODE = "battery_problem_code"
+KEY_SW_VERSION = "sw_version"
 
 
 @dataclass(frozen=True)
@@ -777,6 +787,120 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
     ),
 )
 
+RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_VOLTAGE,
+        name="Battery Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_CURRENT,
+        name="Battery Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_CURRENT),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_POWER,
+        name="Battery Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_POWER),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_PERCENTAGE,
+        name="Battery Percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_PERCENTAGE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_TEMPERATURE,
+        name="Battery Temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_REMAINING_CAPACITY,
+        name="Remaining Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_REMAINING_CAPACITY),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_CAPACITY,
+        name="Nominal Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.get(KEY_BATTERY_CAPACITY),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_CYCLE_COUNT,
+        name="Cycle Count",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.get(KEY_BATTERY_CYCLE_COUNT),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CELL_COUNT,
+        name="Cell Count",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_CELL_COUNT),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CELL_VOLTAGE_MIN,
+        name="Minimum Cell Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MIN),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CELL_VOLTAGE_MAX,
+        name="Maximum Cell Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MAX),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CELL_VOLTAGE_DELTA,
+        name="Cell Voltage Delta",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_DELTA),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_PROBLEM_CODE,
+        name="Problem Code",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_BATTERY_PROBLEM_CODE),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_MODEL,
+        name="Model",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_MODEL),
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SW_VERSION,
+        name="Software Version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get(KEY_SW_VERSION),
+    ),
+)
+
 # All sensors combined (for controller type)
 ALL_SENSORS = BATTERY_SENSORS + PV_SENSORS + LOAD_SENSORS + CONTROLLER_SENSORS
 
@@ -795,6 +919,9 @@ SENSORS_BY_DEVICE_TYPE = {
         "Status": DCC_STATUS_SENSORS,
         "Statistics": DCC_STATISTICS_SENSORS,
         "Diagnostic": DCC_DIAGNOSTIC_SENSORS,
+    },
+    DeviceType.BATTERY.value: {
+        "Battery": RENOGY_BATTERY_SENSORS,
     },
     DeviceType.INVERTER.value: {
         "Inverter": INVERTER_SENSORS,

--- a/custom_components/renogy/strings.json
+++ b/custom_components/renogy/strings.json
@@ -17,7 +17,7 @@
       "already_configured": "Device is already configured",
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
-      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time."
+      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time."
     }
   },
   "options": {

--- a/custom_components/renogy/translations/en.json
+++ b/custom_components/renogy/translations/en.json
@@ -17,7 +17,7 @@
       "already_configured": "Device is already configured",
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
-      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, DCC (DC-DC charger), and shunt300 devices are fully supported at this time."
+      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time."
     }
   },
   "options": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2026.3.0",
-    "renogy-ble==2.2.2",
+    "renogy-ble==2.3.0",
 ]
 
 [dependency-groups]

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -269,6 +269,38 @@ def test_update_device_detects_battery_from_manufacturer_data_only():
     assert device.manufacturer_data == {0xE14C: b"\x01"}
 
 
+def test_update_device_preserves_cached_manufacturer_data() -> None:
+    """Later advertisements should not erase cached manufacturer data."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    initial_service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name=None,
+        rssi=-60,
+    )
+    initial_service_info.advertisement.manufacturer_data = {0xE14C: b"\x01"}
+    coordinator._update_device_from_service_info(initial_service_info)
+
+    later_service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name=None,
+        rssi=-55,
+    )
+    later_service_info.advertisement.manufacturer_data = {}
+
+    device = coordinator._update_device_from_service_info(later_service_info)
+
+    assert coordinator.device_type == "battery"
+    assert device.device_type == "battery"
+    assert device.manufacturer_data == {0xE14C: b"\x01"}
+
+
 def test_intermittent_shunt_device_uses_library_shunt_client():
     """Ensure intermittent SHUNT300 mode keeps using the library shunt client."""
     ble_module = _load_ble_module()

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -128,12 +128,19 @@ def _install_module_stubs() -> None:
     class RenogyBLEDevice:
         """Stub RenogyBLEDevice for testing."""
 
-        def __init__(self, ble_device, advertisement_rssi, device_type=None):
+        def __init__(
+            self,
+            ble_device,
+            advertisement_rssi,
+            device_type=None,
+            manufacturer_data=None,
+        ):
             self.ble_device = ble_device
             self.address = ble_device.address
             self.name = ble_device.name or "Unknown Renogy Device"
             self.rssi = advertisement_rssi
             self.device_type = device_type
+            self.manufacturer_data = manufacturer_data or {}
             self.parsed_data = {}
             self.update_availability = MagicMock()
 
@@ -236,6 +243,30 @@ def test_sustained_shunt_device_defaults_to_generic_client():
     )
 
     assert coordinator._ble_client.__class__.__name__ == "RenogyBleClient"
+
+
+def test_update_device_detects_battery_from_manufacturer_data_only():
+    """Battery manufacturer data should override missing battery name prefixes."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-123456",
+        rssi=-60,
+    )
+    service_info.advertisement.manufacturer_data = {0xE14C: b"\x01"}
+
+    device = coordinator._update_device_from_service_info(service_info)
+
+    assert coordinator.device_type == "battery"
+    assert device.device_type == "battery"
+    assert device.manufacturer_data == {0xE14C: b"\x01"}
 
 
 def test_intermittent_shunt_device_uses_library_shunt_client():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -199,3 +199,71 @@ def test_bluetooth_entry_uses_fallback_title_for_nameless_device() -> None:
             "address": "AA:BB:CC:DD:EE:FF",
         },
     }
+
+
+def test_manual_entry_detects_battery_when_default_type_is_unchanged() -> None:
+    """Manual selection should auto-correct the unchanged controller default."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow = config_flow_module.RenogyConfigFlow()
+    flow._discovered_devices = {
+        "AA:BB:CC:DD:EE:FF": config_flow_module.BluetoothServiceInfoBleak(
+            address="AA:BB:CC:DD:EE:FF",
+            name=None,
+            manufacturer_data={0xE14C: b"\x01"},
+        )
+    }
+
+    entry_result = asyncio.run(
+        flow.async_step_user(
+            {
+                "address": "AA:BB:CC:DD:EE:FF",
+                const_module.CONF_DEVICE_TYPE: const_module.DEFAULT_DEVICE_TYPE,
+                const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            }
+        )
+    )
+
+    assert entry_result == {
+        "type": "create_entry",
+        "title": config_flow_module.UNKNOWN_DEVICE_NAME,
+        "data": {
+            "address": "AA:BB:CC:DD:EE:FF",
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.BATTERY.value,
+            const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+        },
+    }
+
+
+def test_manual_entry_keeps_explicit_device_type_override() -> None:
+    """Manual selection should preserve an explicit non-default override."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow = config_flow_module.RenogyConfigFlow()
+    flow._discovered_devices = {
+        "AA:BB:CC:DD:EE:FF": config_flow_module.BluetoothServiceInfoBleak(
+            address="AA:BB:CC:DD:EE:FF",
+            name=None,
+            manufacturer_data={0xE14C: b"\x01"},
+        )
+    }
+
+    entry_result = asyncio.run(
+        flow.async_step_user(
+            {
+                "address": "AA:BB:CC:DD:EE:FF",
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
+                const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            }
+        )
+    )
+
+    assert entry_result == {
+        "type": "create_entry",
+        "title": config_flow_module.UNKNOWN_DEVICE_NAME,
+        "data": {
+            "address": "AA:BB:CC:DD:EE:FF",
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
+            const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+        },
+    }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,201 @@
+"""Tests for Renogy BLE config-flow behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+
+def _load_config_flow_module() -> Any:
+    """Load config_flow with minimal Home Assistant stubs."""
+    repo_root = Path(__file__).resolve().parents[1]
+    custom_components_path = str(repo_root / "custom_components")
+    renogy_path = str(repo_root / "custom_components" / "renogy")
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [custom_components_path]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    renogy_pkg = types.ModuleType("custom_components.renogy")
+    renogy_pkg.__path__ = [renogy_path]
+    sys.modules["custom_components.renogy"] = renogy_pkg
+
+    homeassistant_module = cast(Any, types.ModuleType("homeassistant"))
+    sys.modules["homeassistant"] = homeassistant_module
+
+    components_module = cast(Any, types.ModuleType("homeassistant.components"))
+    sys.modules["homeassistant.components"] = components_module
+
+    bluetooth_module = cast(Any, types.ModuleType("homeassistant.components.bluetooth"))
+
+    class BluetoothServiceInfoBleak:
+        """Stub BluetoothServiceInfoBleak for config-flow tests."""
+
+        def __init__(
+            self,
+            address: str,
+            name: str | None,
+            manufacturer_data: dict[int, bytes] | None = None,
+        ) -> None:
+            """Initialize the bluetooth discovery object."""
+            self.address = address
+            self.name = name
+            self.device = MagicMock()
+            self.device.address = address
+            self.device.name = name
+            self.device.rssi = -60
+            self.advertisement = MagicMock()
+            self.advertisement.rssi = -60
+            self.advertisement.manufacturer_data = manufacturer_data or {}
+
+    bluetooth_module.BluetoothServiceInfoBleak = BluetoothServiceInfoBleak
+    bluetooth_module.async_discovered_service_info = MagicMock(return_value=[])
+    sys.modules["homeassistant.components.bluetooth"] = bluetooth_module
+    components_module.bluetooth = bluetooth_module
+
+    config_entries_module = cast(Any, types.ModuleType("homeassistant.config_entries"))
+
+    class ConfigEntry:
+        """Stub ConfigEntry class for config-flow imports."""
+
+    class ConfigFlow:
+        """Stub ConfigFlow with the methods used by this integration."""
+
+        def __init_subclass__(cls, *, domain: str | None = None, **kwargs: Any) -> None:
+            """Accept Home Assistant's domain keyword during subclassing."""
+            super().__init_subclass__(**kwargs)
+            cls.domain = domain
+
+        def __init__(self) -> None:
+            """Initialize config-flow state."""
+            self.context: dict[str, Any] = {}
+
+        async def async_set_unique_id(
+            self, unique_id: str, raise_on_progress: bool = True
+        ) -> None:
+            """Record the unique ID for the flow."""
+            self.unique_id = unique_id
+            self.raise_on_progress = raise_on_progress
+
+        def _abort_if_unique_id_configured(self) -> None:
+            """Pretend no existing entry is configured."""
+
+        def async_show_form(
+            self,
+            *,
+            step_id: str,
+            data_schema: Any,
+            description_placeholders: dict[str, str] | None = None,
+            errors: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            """Return a Home Assistant-like form result."""
+            return {
+                "type": "form",
+                "step_id": step_id,
+                "data_schema": data_schema,
+                "description_placeholders": description_placeholders or {},
+                "errors": errors or {},
+            }
+
+        def async_create_entry(self, *, title: str, data: Any) -> dict[str, Any]:
+            """Return a Home Assistant-like create-entry result."""
+            return {"type": "create_entry", "title": title, "data": data}
+
+        def async_abort(
+            self,
+            *,
+            reason: str,
+            description_placeholders: dict[str, str] | None = None,
+        ) -> dict[str, Any]:
+            """Return a Home Assistant-like abort result."""
+            return {
+                "type": "abort",
+                "reason": reason,
+                "description_placeholders": description_placeholders or {},
+            }
+
+    class OptionsFlow:
+        """Stub OptionsFlow for config-flow imports."""
+
+        def async_show_form(self, *, step_id: str, data_schema: Any) -> dict[str, Any]:
+            """Return a Home Assistant-like options-form result."""
+            return {"type": "form", "step_id": step_id, "data_schema": data_schema}
+
+        def async_create_entry(self, *, title: str, data: Any) -> dict[str, Any]:
+            """Return a Home Assistant-like options-entry result."""
+            return {"type": "create_entry", "title": title, "data": data}
+
+    config_entries_module.ConfigEntry = ConfigEntry
+    config_entries_module.ConfigFlow = ConfigFlow
+    config_entries_module.ConfigFlowResult = dict[str, Any]
+    config_entries_module.OptionsFlow = OptionsFlow
+    sys.modules["homeassistant.config_entries"] = config_entries_module
+
+    const_module = cast(Any, types.ModuleType("homeassistant.const"))
+    const_module.CONF_ADDRESS = "address"
+    const_module.CONF_SCAN_INTERVAL = "scan_interval"
+    sys.modules["homeassistant.const"] = const_module
+
+    sys.modules.pop("custom_components.renogy.const", None)
+    sys.modules.pop("custom_components.renogy.device_name", None)
+    sys.modules.pop("custom_components.renogy.config_flow", None)
+    return importlib.import_module("custom_components.renogy.config_flow")
+
+
+def test_bluetooth_discovery_uses_fallback_name_for_nameless_device() -> None:
+    """Nameless bluetooth matches should use a stable fallback display name."""
+    config_flow_module = _load_config_flow_module()
+    flow = config_flow_module.RenogyConfigFlow()
+    flow.context = {}
+    discovery_info = config_flow_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name=None,
+        manufacturer_data={0xE14C: b"\x01"},
+    )
+
+    form_result = asyncio.run(flow.async_step_bluetooth(discovery_info))
+
+    assert form_result["type"] == "form"
+    assert form_result["description_placeholders"]["device_name"] == (
+        config_flow_module.UNKNOWN_DEVICE_NAME
+    )
+    assert flow.context["title_placeholders"] == {
+        "name": config_flow_module.UNKNOWN_DEVICE_NAME,
+        "address": "AA:BB:CC:DD:EE:FF",
+    }
+
+
+def test_bluetooth_entry_uses_fallback_title_for_nameless_device() -> None:
+    """Nameless bluetooth matches should not create entries with None titles."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow = config_flow_module.RenogyConfigFlow()
+    flow._discovered_device = config_flow_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name=None,
+        manufacturer_data={0xE14C: b"\x01"},
+    )
+
+    entry_result = asyncio.run(
+        flow.async_step_user(
+            {
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.BATTERY.value,
+                const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            }
+        )
+    )
+
+    assert entry_result == {
+        "type": "create_entry",
+        "title": config_flow_module.UNKNOWN_DEVICE_NAME,
+        "data": {
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.BATTERY.value,
+            const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            "address": "AA:BB:CC:DD:EE:FF",
+        },
+    }

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -34,6 +34,8 @@ def test_supported_renogy_name_prefixes() -> None:
 
     assert device_name_module.is_supported_renogy_ble_name("BT-TH-123456")
     assert device_name_module.is_supported_renogy_ble_name("RNGRIU123456")
+    assert device_name_module.is_supported_renogy_ble_name("RNGRBP123456")
+    assert device_name_module.is_supported_renogy_ble_name("RNGC123456")
     assert device_name_module.is_supported_renogy_ble_name(
         f"{device_name_module.SHUNT300_BT_PREFIX}A1B2"
     )
@@ -49,6 +51,14 @@ def test_detect_device_type_from_ble_name() -> None:
     assert (
         device_name_module.detect_device_type_from_ble_name("RNGRIU123456")
         == const_module.DeviceType.INVERTER.value
+    )
+    assert (
+        device_name_module.detect_device_type_from_ble_name("RNGRBP123456")
+        == const_module.DeviceType.BATTERY.value
+    )
+    assert (
+        device_name_module.detect_device_type_from_ble_name("RNGC123456")
+        == const_module.DeviceType.BATTERY.value
     )
     assert (
         device_name_module.detect_device_type_from_ble_name("RTMShunt300A1B2")
@@ -75,6 +85,9 @@ def test_is_device_name_ready_by_device_type() -> None:
     )
     assert device_name_module.is_device_name_ready(
         "RNGRIU123456", const_module.DeviceType.INVERTER.value
+    )
+    assert device_name_module.is_device_name_ready(
+        "RNGRBP123456", const_module.DeviceType.BATTERY.value
     )
     assert not device_name_module.is_device_name_ready(
         "RTMShunt300A1B2", const_module.DeviceType.CONTROLLER.value

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -33,9 +33,13 @@ def test_supported_renogy_name_prefixes() -> None:
     device_name_module = _load_device_name_module()
 
     assert device_name_module.is_supported_renogy_ble_name("BT-TH-123456")
+    assert device_name_module.is_supported_renogy_ble_name("BT-TH-BATT01")
     assert device_name_module.is_supported_renogy_ble_name("RNGRIU123456")
     assert device_name_module.is_supported_renogy_ble_name("RNGRBP123456")
     assert device_name_module.is_supported_renogy_ble_name("RNGC123456")
+    assert device_name_module.is_supported_renogy_ble_name(
+        None, manufacturer_data={0xE14C: b"\x01"}
+    )
     assert device_name_module.is_supported_renogy_ble_name(
         f"{device_name_module.SHUNT300_BT_PREFIX}A1B2"
     )
@@ -58,6 +62,16 @@ def test_detect_device_type_from_ble_name() -> None:
     )
     assert (
         device_name_module.detect_device_type_from_ble_name("RNGC123456")
+        == const_module.DeviceType.BATTERY.value
+    )
+    assert (
+        device_name_module.detect_device_type_from_ble_name("BT-TH-BATTERY01")
+        == const_module.DeviceType.BATTERY.value
+    )
+    assert (
+        device_name_module.detect_device_type_from_ble_name(
+            None, manufacturer_data={0xE14C: b"\x01"}
+        )
         == const_module.DeviceType.BATTERY.value
     )
     assert (
@@ -88,6 +102,9 @@ def test_is_device_name_ready_by_device_type() -> None:
     )
     assert device_name_module.is_device_name_ready(
         "RNGRBP123456", const_module.DeviceType.BATTERY.value
+    )
+    assert device_name_module.is_device_name_ready(
+        "BT-TH-BATTERY01", const_module.DeviceType.BATTERY.value
     )
     assert not device_name_module.is_device_name_ready(
         "RTMShunt300A1B2", const_module.DeviceType.CONTROLLER.value

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -417,3 +417,39 @@ def test_inverter_sensor_mapping_uses_library_field_names() -> None:
     assert (
         descriptions[sensor_module.KEY_MODEL].value_fn(sample_data) == "RIV1220PU-126"
     )
+
+
+def test_battery_sensor_mapping_uses_library_field_names() -> None:
+    """Ensure battery entities map directly to renogy-ble battery data keys."""
+    sensor_module = _load_sensor_module()
+
+    descriptions = {
+        description.key: description
+        for description in sensor_module.RENOGY_BATTERY_SENSORS
+    }
+    sample_data = {
+        sensor_module.KEY_BATTERY_VOLTAGE: 51.2,
+        sensor_module.KEY_BATTERY_CURRENT: 12.34,
+        sensor_module.KEY_BATTERY_POWER: 631.8,
+        sensor_module.KEY_BATTERY_PERCENTAGE: 50.0,
+        sensor_module.KEY_BATTERY_TEMPERATURE: 22.0,
+        sensor_module.KEY_BATTERY_REMAINING_CAPACITY: 50.0,
+        sensor_module.KEY_BATTERY_CAPACITY: 100,
+        sensor_module.KEY_BATTERY_CYCLE_COUNT: 42,
+        sensor_module.KEY_CELL_COUNT: 4,
+        sensor_module.KEY_CELL_VOLTAGE_MIN: 32.9,
+        sensor_module.KEY_CELL_VOLTAGE_MAX: 33.2,
+        sensor_module.KEY_CELL_VOLTAGE_DELTA: 0.3,
+        sensor_module.KEY_BATTERY_PROBLEM_CODE: 16,
+        sensor_module.KEY_MODEL: "Renogy BT Battery Pro",
+        sensor_module.KEY_SW_VERSION: "2.10",
+    }
+
+    assert descriptions[sensor_module.KEY_BATTERY_VOLTAGE].value_fn(sample_data) == 51.2
+    assert descriptions[sensor_module.KEY_BATTERY_POWER].value_fn(sample_data) == 631.8
+    assert descriptions[sensor_module.KEY_BATTERY_CAPACITY].value_fn(sample_data) == 100
+    assert descriptions[sensor_module.KEY_CELL_COUNT].value_fn(sample_data) == 4
+    assert (
+        descriptions[sensor_module.KEY_CELL_VOLTAGE_DELTA].value_fn(sample_data) == 0.3
+    )
+    assert descriptions[sensor_module.KEY_SW_VERSION].value_fn(sample_data) == "2.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1409,20 +1409,20 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.2.2"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/e5/72ce8d2620f76d874b4ea5b7f72c5b90b9571e6f24df38bfdaa7ca3054fe/renogy_ble-2.2.2.tar.gz", hash = "sha256:5e8038e291aa625b82610a6b92deb4122fc20cd5781ccd1dcd3d5289c921f100", size = 57879, upload-time = "2026-03-22T17:04:42.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/82/3370c946c5abf1ee3d3ae46b5ad0e5a7343be2dc24c382c01453a295df44/renogy_ble-2.3.0.tar.gz", hash = "sha256:4b88fc5471ed2f97ab8ece271c5dcbd6dada44d082f1b6ae8420b0ececd39c12", size = 63458, upload-time = "2026-04-03T21:45:13.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/f5/d8587a86bcd215f19a738a182fecf585b179f15495502563405ff14e03b4/renogy_ble-2.2.2-py3-none-any.whl", hash = "sha256:daa6635dd18eb7bc22795481d58662f918723c7661ddde874d13045f8b1828df", size = 25078, upload-time = "2026-03-22T17:04:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ae/0dc085d602b020291c638e750e078a6739311dc579ebd6d5f3452dd90ce8/renogy_ble-2.3.0-py3-none-any.whl", hash = "sha256:8ba9682d3cc888d7547ef176c579020418eb5cb7f88fd784a7034396c57ef9df", size = 28482, upload-time = "2026-04-03T21:45:15.163Z" },
 ]
 
 [[package]]
 name = "renogy-ha"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },
@@ -1440,7 +1440,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "renogy-ble", specifier = "==2.2.2" },
+    { name = "renogy-ble", specifier = "==2.3.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What changed
- added Home Assistant support for Renogy battery config entries and entity creation
- expanded discovery for unambiguous Renogy battery BLE names (`RNGRBP*` and `RNGC*`)
- added battery-specific sensor mappings for the new `renogy-ble` battery fields
- updated tests for battery discovery and sensor field mapping

## Why
The integration needed to consume the new `renogy-ble` battery support and expose battery devices without regressing existing controller, DCC, inverter, or shunt handling.

## Impact
Supported Renogy battery devices can now be configured in `renogy-ha` and surface battery-focused telemetry entities.

## Validation
- `PYTHONPATH=/home/mitchell/home_assistant/renogy/renogy-worktrees/renogy-ble-rbl-qbu/src uv run ruff format .`
- `PYTHONPATH=/home/mitchell/home_assistant/renogy/renogy-worktrees/renogy-ble-rbl-qbu/src uv run ruff check . --output-format=github`
- `PYTHONPATH=/home/mitchell/home_assistant/renogy/renogy-worktrees/renogy-ble-rbl-qbu/src uv run ty check . --output-format=github`
- `PYTHONPATH=/home/mitchell/home_assistant/renogy/renogy-worktrees/renogy-ble-rbl-qbu/src uv run pytest tests`

## Follow-up
Legacy `BT-TH-*` battery advertisements still overlap with controller-style devices, so automatic classification remains conservative there. Follow-up issue: `rha-0mo`.
