### PR TITLE
[codex] Add raw_words parity for sustained Smart Shunt updates

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -580,6 +580,10 @@ class RenogyActiveBluetoothCoordinator(
             parsed_data["energy_charged_total"] = round(charged_kwh, 3)
             parsed_data["energy_discharged_total"] = round(discharged_kwh, 3)
         parsed_data["raw_payload"] = raw_payload.hex()
+        parsed_data["raw_words"] = [
+            int.from_bytes(raw_payload[i : i + 2], "big", signed=False)
+            for i in range(0, len(raw_payload), 2)
+        ]
 
         changed = any(
             parsed_data.get(key) != self._last_sustained_shunt_data.get(key)

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -550,6 +550,40 @@ def test_sustained_shunt_notification_ignores_duplicate_payloads():
     assert listener.call_count == 1
 
 
+def test_sustained_shunt_notification_populates_raw_words():
+    """Ensure sustained shunt updates expose raw_words for diagnostics."""
+    ble_module = _load_ble_module()
+    hass = MagicMock()
+    hass.loop.call_soon_threadsafe = lambda callback: callback()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=hass,
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="shunt300",
+        shunt_connection_mode="sustained",
+    )
+    coordinator.device = MagicMock(parsed_data={})
+
+    payload = (
+        b"\x12\x34\xab\xcd",
+        {
+            "shunt_voltage": 13.2,
+            "shunt_current": 1.5,
+            "shunt_power": 19.8,
+            "shunt_soc": 85.0,
+        },
+    )
+    ble_module.shunt_find_valid_payload_window = MagicMock(return_value=payload)
+
+    with patch.object(ble_module.time, "monotonic", return_value=100.0):
+        assert coordinator._process_sustained_shunt_notification(b"payload") is True
+
+    assert coordinator.data["raw_payload"] == "1234abcd"
+    assert coordinator.data["raw_words"] == [0x1234, 0xABCD]
+    assert coordinator.device.parsed_data["raw_words"] == [0x1234, 0xABCD]
+
+
 def test_sustained_shunt_notification_recovers_from_duplicate_payload_after_error():
     """Ensure duplicate payloads still restore availability after listener errors."""
     ble_module = _load_ble_module()


### PR DESCRIPTION
## Summary
- add `raw_words` generation to the sustained Smart Shunt notification path
- keep sustained-mode troubleshooting attributes aligned with intermittent shunt diagnostics
- cover the sustained notification path with a focused raw_words test

## Why
Old PR #105 included a useful shunt diagnostics fix that was still missing on current `main`: sustained Smart Shunt updates exposed `raw_payload` but not `raw_words`. That made troubleshooting inconsistent across shunt connection modes.

## Impact
Sustained-mode Smart Shunt entities now surface the same low-level diagnostic payload breakdown already available in intermittent mode, without pulling in any of the old health-card or unrelated PR work.

## Validation
- `uv run pytest tests/test_ble.py -k 'sustained_shunt_notification'`
- `uv run pytest tests/test_ble.py tests/test_sensor_setup.py`

Co-authored-by: rs-mini-rgb <rs-mini-rgb@users.noreply.github.com>