### PR TITLE
fix: handle shunt energy restore upgrades without metadata

### DIFF
--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -1079,6 +1079,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
         self._energy_last_adjusted: float | None = None
         self._energy_reset_count = 0
         self._energy_last_reset: str | None = None
+        self._energy_restore_without_metadata = False
 
         # Generate a device model name that includes the device type
         device_model = f"Renogy {device_type.capitalize()}"
@@ -1131,6 +1132,9 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
             self._attr_native_value = self._energy_last_adjusted
 
         if last_extra_data is None:
+            self._energy_restore_without_metadata = (
+                self._energy_last_adjusted is not None
+            )
             return
 
         extra_data = last_extra_data.as_dict()
@@ -1403,6 +1407,16 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
         raw_value = _coerce_float(value, default=0.0)
         if raw_value is None:
             raw_value = 0.0
+
+        if (
+            self._energy_restore_without_metadata
+            and self._energy_last_adjusted is not None
+            and self._energy_last_raw is None
+        ):
+            # Older versions restored only the adjusted total, so reconstruct the
+            # best available offset from the first post-upgrade raw sample.
+            self._energy_offset = max(self._energy_last_adjusted - raw_value, 0.0)
+            self._energy_restore_without_metadata = False
 
         adjusted = raw_value + self._energy_offset
 

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -527,6 +527,54 @@ def test_shunt_energy_counter_restores_offset_after_restart() -> None:
     assert entity.extra_restore_state_data.as_dict()["offset"] == 1.0
 
 
+def test_shunt_energy_counter_restores_without_extra_metadata() -> None:
+    """Ensure upgrades from older restore data do not move the total backward."""
+    sensor_module = _load_sensor_module()
+
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+    coordinator.device = None
+    coordinator.last_update_success = True
+    coordinator.data = {}
+
+    device = MagicMock()
+    device.address = "AA:BB:CC:DD:EE:FF"
+    device.name = "RTMShunt300A1B2"
+    device.rssi = None
+    device.parsed_data = {
+        sensor_module.KEY_SHUNT_ENERGY_CHARGED_TOTAL: 0.3,
+    }
+
+    description = next(
+        item
+        for item in sensor_module.SHUNT300_SENSORS
+        if item.key == sensor_module.KEY_SHUNT_ENERGY_CHARGED_TOTAL
+    )
+
+    entity = sensor_module.RenogyBLESensor(
+        coordinator,
+        device,
+        description,
+        "Shunt",
+        sensor_module.DeviceType.SHUNT300.value,
+    )
+    entity._mock_last_state = types.SimpleNamespace(state="1.2")
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.native_value == 1.2
+
+    entity._attr_native_value = None
+
+    assert entity.native_value == 1.2
+    assert round(entity.extra_restore_state_data.as_dict()["offset"], 3) == 0.9
+
+    entity._attr_native_value = None
+    device.parsed_data[sensor_module.KEY_SHUNT_ENERGY_CHARGED_TOTAL] = 0.4
+
+    assert entity.native_value == 1.3
+
+
 def test_inverter_sensor_mapping_uses_library_field_names() -> None:
     """Ensure inverter entities map directly to renogy-ble parsed field names."""
     sensor_module = _load_sensor_module()


### PR DESCRIPTION
## Summary
- preserve monotonic shunt energy totals when upgrading from versions that only restored the last entity state
- derive a one-shot fallback offset from the first post-restore raw sample when extra restore metadata is missing
- add regression coverage for the no-metadata upgrade path

## Validation
- uv run ruff format .
- uv run ruff check . --output-format=github
- uv run ty check . --output-format=github
- uv run pytest tests

Follow-up for review feedback from #124: https://github.com/IAmTheMitchell/renogy-ha/pull/124#discussion_r3034882668