### PR TITLE
[codex] Defer renogy-ble import until setup

### DIFF
--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 
-from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
@@ -26,6 +25,9 @@ from .const import (
 )
 from .device_name import has_real_device_name
 
+if TYPE_CHECKING:
+    from .ble import RenogyBLEDevice
+
 # List of platforms this integration supports
 PLATFORMS = [Platform.SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
 
@@ -39,6 +41,8 @@ class _CoordinatorShutdownProtocol(Protocol):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Renogy BLE from a config entry."""
+    from .ble import RenogyActiveBluetoothCoordinator
+
     LOGGER.info("Setting up Renogy BLE integration with entry %s", entry.entry_id)
 
     # Get configuration from entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 
-def _install_module_stubs() -> type:
+def _install_module_stubs(*, install_ble: bool = True) -> type | None:
     """Install minimal module stubs to import the integration module."""
     homeassistant_module = cast(Any, types.ModuleType("homeassistant"))
     sys.modules["homeassistant"] = homeassistant_module
@@ -50,6 +50,10 @@ def _install_module_stubs() -> type:
     )
     device_registry_module.async_get = MagicMock()
     sys.modules["homeassistant.helpers.device_registry"] = device_registry_module
+
+    if not install_ble:
+        sys.modules.pop("custom_components.renogy.ble", None)
+        return None
 
     ble_module = cast(Any, types.ModuleType("custom_components.renogy.ble"))
 
@@ -90,6 +94,17 @@ def _load_init_module():
     sys.modules.pop("custom_components.renogy", None)
     module = importlib.import_module("custom_components.renogy")
     return module, coordinator_class
+
+
+def test_init_module_imports_without_ble_dependency() -> None:
+    """Ensure component import does not require manifest requirements yet."""
+    _install_module_stubs(install_ble=False)
+    sys.modules.pop("custom_components.renogy.__init__", None)
+    sys.modules.pop("custom_components.renogy", None)
+
+    module = importlib.import_module("custom_components.renogy")
+
+    assert module.DOMAIN == "renogy"
 
 
 def test_shunt_connection_mode_defaults_to_sustained() -> None:


### PR DESCRIPTION
## Summary

Defers importing the BLE coordinator until `async_setup_entry` runs so the integration package can be imported before Home Assistant has installed manifest requirements.

## Root Cause

`custom_components/renogy/__init__.py` imported `.ble` at module import time, and `.ble` imports `renogy_ble`. Some Home Assistant 2026.4 config-entry paths import the component package before processing manifest requirements, which can surface as `ModuleNotFoundError: No module named 'renogy_ble'` on a fresh or upgraded install.

## Validation

- `uv run pytest tests`
- `uv run ruff format . --check`
- `uv run ruff check . --output-format=github`
- `uv run ty check . --output-format=github`