### PR TITLE
Recognize RNGPRO-family battery advertisements

### DIFF
--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -15,7 +15,7 @@ MAX_SCAN_INTERVAL = 600  # seconds
 # Renogy BT-1 and BT-2 module identifiers - devices advertise with these prefixes
 RENOGY_BT_PREFIX = "BT-TH-"
 RENOGY_INVERTER_PREFIX = "RNGRIU"
-RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC")
+RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC", "RNGPRO")
 
 # Configuration parameters
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -15,6 +15,9 @@
       "local_name": "RNGC*"
     },
     {
+      "local_name": "RNGPRO*"
+    },
+    {
       "local_name": "RTMShunt300*"
     },
     {

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -35,7 +35,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.3.1"
+    "renogy-ble==2.4.0"
   ],
   "version": "0.7.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2026.5.4",
-    "renogy-ble==2.3.1",
+    "renogy-ble==2.4.0",
 ]
 
 [dependency-groups]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import json
 import sys
 import types
 from pathlib import Path
@@ -166,6 +167,41 @@ def test_bluetooth_discovery_uses_fallback_name_for_nameless_device() -> None:
     )
     assert flow.context["title_placeholders"] == {
         "name": config_flow_module.UNKNOWN_DEVICE_NAME,
+        "address": "AA:BB:CC:DD:EE:FF",
+    }
+
+
+def test_manifest_registers_rngpro_bluetooth_discovery() -> None:
+    """The manifest should subscribe Home Assistant to RNGPRO advertisements."""
+    manifest_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "renogy"
+        / "manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text())
+
+    assert {"local_name": "RNGPRO*"} in manifest["bluetooth"]
+
+
+def test_bluetooth_discovery_routes_rngpro_to_battery() -> None:
+    """RNGPRO bluetooth discovery should default to the battery device type."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow = config_flow_module.RenogyConfigFlow()
+    flow.context = {}
+    discovery_info = config_flow_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="RNGPRO125BAT-EF036881",
+    )
+
+    form_result = asyncio.run(flow.async_step_bluetooth(discovery_info))
+
+    assert form_result["type"] == "form"
+    assert flow._discovered_device is discovery_info
+    assert flow._default_device_type == const_module.DeviceType.BATTERY.value
+    assert flow.context["title_placeholders"] == {
+        "name": "RNGPRO125BAT-EF036881",
         "address": "AA:BB:CC:DD:EE:FF",
     }
 

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -37,6 +37,7 @@ def test_supported_renogy_name_prefixes() -> None:
     assert device_name_module.is_supported_renogy_ble_name("RNGRIU123456")
     assert device_name_module.is_supported_renogy_ble_name("RNGRBP123456")
     assert device_name_module.is_supported_renogy_ble_name("RNGC123456")
+    assert device_name_module.is_supported_renogy_ble_name("RNGPRO125BAT-EF036881")
     assert device_name_module.is_supported_renogy_ble_name(
         None, manufacturer_data={0xE14C: b"\x01"}
     )
@@ -62,6 +63,10 @@ def test_detect_device_type_from_ble_name() -> None:
     )
     assert (
         device_name_module.detect_device_type_from_ble_name("RNGC123456")
+        == const_module.DeviceType.BATTERY.value
+    )
+    assert (
+        device_name_module.detect_device_type_from_ble_name("RNGPRO125BAT-EF036881")
         == const_module.DeviceType.BATTERY.value
     )
     assert (
@@ -102,6 +107,9 @@ def test_is_device_name_ready_by_device_type() -> None:
     )
     assert device_name_module.is_device_name_ready(
         "RNGRBP123456", const_module.DeviceType.BATTERY.value
+    )
+    assert device_name_module.is_device_name_ready(
+        "RNGPRO125BAT-EF036881", const_module.DeviceType.BATTERY.value
     )
     assert device_name_module.is_device_name_ready(
         "BT-TH-BATTERY01", const_module.DeviceType.BATTERY.value

--- a/uv.lock
+++ b/uv.lock
@@ -1505,15 +1505,15 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.3.1"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/94/4a41c498cd0b5437ccab3c88f405c35db452e1ca69db8f2f746a145b4e3e/renogy_ble-2.3.1.tar.gz", hash = "sha256:9cc1614f01d90d910e5d57eb762e08504af0a8fed03ab2fc65827d3b2c23c76b", size = 65074, upload-time = "2026-04-19T17:52:09.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/dd/5588e9a8e8b7205108a95afbf3d5dd01060b6c888ad850f5ef84bf9803e8/renogy_ble-2.4.0.tar.gz", hash = "sha256:45a798202cc6ba1f9f6b69dc41d0c1c2ab5937431f01f3545a3ce0d4265294db", size = 67089, upload-time = "2026-07-23T02:39:25.945Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/27/ac766a31cff2ea44aca67c04ed568b9afc9c1072863a71f0bfc899fbe551/renogy_ble-2.3.1-py3-none-any.whl", hash = "sha256:0ab3c5b49befd1b3eb14ad68bc3664408f499e43fe554b2c16702d76fe7ccabf", size = 29105, upload-time = "2026-04-19T17:52:10.36Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f7/4a96e817329403805e007750c3d7f757281cbb440dda13fcb253930fcbca/renogy_ble-2.4.0-py3-none-any.whl", hash = "sha256:b3bea5998492f1e530b3e7e589dd1c12b7bb895ffac284904847328a68a6756e", size = 29526, upload-time = "2026-07-23T02:39:25.018Z" },
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.5.4" },
-    { name = "renogy-ble", specifier = "==2.3.1" },
+    { name = "renogy-ble", specifier = "==2.4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Recognize Renogy RNGPRO-family batteries — e.g. **RBT12500LFP-SHBT**, which advertises as `RNGPRO125BAT-*`. They were not matched by the battery name prefixes, so the config flow never offered them and automatic Bluetooth discovery ignored them.

- add `"RNGPRO"` to `RENOGY_BATTERY_PRO_PREFIXES` (propagates to device-type classification and the config-flow scan filter)
- add an `RNGPRO*` `local_name` matcher to the manifest for automatic discovery

## Dependency

Parsing/scaling for this family is handled by a new `rngpro` variant in **renogy-ble** (IAmTheMitchell/renogy-ble#120). This PR intentionally leaves `requirements` at `renogy-ble==2.3.1`; it should be bumped to the first renogy-ble release that includes the `rngpro` variant. Without that bump a detected RNGPRO battery will connect but decode with the wrong scaling, so this PR is best merged after #120 is released.

## Testing

Tested on my own hardware — battery **RBT12500LFP-SHBT** (12 V / 500 Ah) and DC-DC charger **DCC50S** — running this branch against the renogy-ble change above: the battery is auto-discovered, added, and all entities read correctly (current, per-cell voltages, temperatures, SoC, capacity), with no change to how the DCC50S is handled.

I have no other Renogy devices, so **I cannot test for regressions on other models** (other batteries, charge controllers, inverters, shunts). The change only adds a new name prefix/matcher and does not alter existing device handling.
