### PR TITLE
feat: add model-based device type detection and reconfigure flow

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -39,7 +39,11 @@ from .const import (
     NonShuntConnectionMode,
     ShuntConnectionMode,
 )
-from .device_name import detect_device_type_from_ble_name, has_real_device_name
+from .device_name import (
+    detect_device_type_from_ble_name,
+    detect_device_type_from_model,
+    has_real_device_name,
+)
 
 # Check if write_register is available in the library.
 try:
@@ -151,6 +155,9 @@ class RenogyActiveBluetoothCoordinator(
         # Add connection lock to prevent multiple concurrent connections
         self._connection_lock = asyncio.Lock()
         self._connection_in_progress = False
+
+        # Warn only once when the reported model contradicts the configured type
+        self._model_mismatch_warned = False
 
     def _build_ble_client_for_type(self, device_type: str) -> RenogyBleClient:
         """Build a BLE client suitable for the configured device type."""
@@ -923,10 +930,37 @@ class RenogyActiveBluetoothCoordinator(
                 if success and device.parsed_data:
                     self.data = dict(device.parsed_data)
                     self.logger.debug("Updated coordinator data: %s", self.data)
+                    self._warn_if_model_mismatch()
 
                 return success
             finally:
                 self._connection_in_progress = False
+
+    def _warn_if_model_mismatch(self) -> None:
+        """Warn once when the reported model implies a different device type.
+
+        A BT-TH module advertises the same BLE name regardless of the device
+        behind it, so entries can end up configured as the default type even
+        though the model register identifies e.g. a DC-DC charger.
+        """
+        if self._model_mismatch_warned or not self.data:
+            return
+
+        model = self.data.get("model")
+        detected_type = detect_device_type_from_model(model)
+        if detected_type is None or detected_type == self.device_type:
+            return
+
+        self._model_mismatch_warned = True
+        self.logger.warning(
+            "Device %s reports model %s, which is a '%s' device, but this "
+            "entry is configured as '%s'. Reconfigure the integration entry "
+            "to switch the device type and unlock the correct entities.",
+            self.address,
+            model,
+            detected_type,
+            self.device_type,
+        )
 
     async def async_set_load_state(self, state: bool) -> bool:
         """Set the DC load on/off."""

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -37,6 +37,7 @@ from .const import (
 )
 from .device_name import (
     detect_device_type_from_ble_name,
+    detect_device_type_from_model,
     has_real_device_name,
     is_supported_renogy_ble_name,
 )
@@ -258,6 +259,71 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
             },
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Allow changing the device type and scan interval in place.
+
+        This is the supported way to fix an entry that was set up with the
+        wrong device type (e.g. a DC-DC charger behind a BT-TH module that
+        defaulted to 'controller'), without deleting the entry.
+        """
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            device_type = user_input[CONF_DEVICE_TYPE]
+            if device_type not in SUPPORTED_DEVICE_TYPES:
+                LOGGER.warning("Unsupported device type selected: %s", device_type)
+                return self.async_abort(
+                    reason="unsupported_device_type",
+                    description_placeholders={"device_type": device_type},
+                )
+
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates={
+                    CONF_DEVICE_TYPE: device_type,
+                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
+                },
+            )
+
+        current_type = entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+        suggested_type = (
+            self._detect_device_type_from_coordinator(entry) or current_type
+        )
+        current_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+        reconfigure_schema = vol.Schema(
+            {
+                vol.Required(CONF_DEVICE_TYPE, default=suggested_type): vol.In(
+                    DEVICE_TYPES
+                ),
+                vol.Optional(CONF_SCAN_INTERVAL, default=current_interval): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=reconfigure_schema,
+            description_placeholders={
+                "device_name": entry.title,
+                "current_device_type": current_type,
+            },
+        )
+
+    def _detect_device_type_from_coordinator(self, entry: ConfigEntry) -> str | None:
+        """Detect the device type from the model the coordinator last read."""
+        try:
+            entry_data = self.hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+            coordinator = entry_data.get("coordinator")
+            model = (coordinator.data or {}).get("model") if coordinator else None
+        except AttributeError:
+            return None
+        return detect_device_type_from_model(model)
 
     async def _async_discover_devices(self) -> None:
         """Discover Bluetooth devices."""

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from .const import (
     DEFAULT_DEVICE_TYPE,
     RENOGY_BATTERY_PRO_PREFIXES,
@@ -11,6 +13,11 @@ from .const import (
 )
 
 UNKNOWN_DEVICE_NAME_PREFIX = "Unknown"
+
+# DC-DC charger model families: DCC30S/DCC50S and their successors
+# RBC20D1U/RBC30D1S/RBC50D1S(-G6) etc. The "D" after the amperage marks
+# the DC input variant (AC chargers use a different letter).
+DCC_MODEL_PATTERN = re.compile(r"^(DCC|RBC\d+D)", re.IGNORECASE)
 SHUNT300_BT_PREFIX = "RTMShunt300"
 BATTERY_LEGACY_NAME_MARKERS = ("BATT", "BATTERY")
 BATTERY_PRO_MANUFACTURER_ID = 0xE14C
@@ -85,6 +92,26 @@ def detect_device_type_from_ble_name(
         return DeviceType.BATTERY.value
 
     return default_device_type
+
+
+def detect_device_type_from_model(model: str | None) -> str | None:
+    """Infer the device type from a device-reported model string.
+
+    BLE names cannot distinguish a BT-TH module on a solar controller from
+    one on a DC-DC charger, but the model register can. Returns None when
+    the model does not identify a specific device type.
+    """
+    if not isinstance(model, str):
+        return None
+
+    normalized = model.strip()
+    if not normalized:
+        return None
+
+    if DCC_MODEL_PATTERN.match(normalized):
+        return DeviceType.DCC.value
+
+    return None
 
 
 def _is_legacy_battery_name(device_name: str) -> bool:

--- a/custom_components/renogy/strings.json
+++ b/custom_components/renogy/strings.json
@@ -8,6 +8,13 @@
           "scan_interval": "Polling interval (seconds)",
           "device_type": "Device Type"
         }
+      },
+      "reconfigure": {
+        "description": "Reconfigure Renogy BLE device: {device_name}. \n\nCurrent device type: {current_device_type}. Changing the device type replaces the entities with the set matching the new type.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)",
+          "device_type": "Device Type"
+        }
       }
     },
     "error": {
@@ -17,7 +24,8 @@
       "already_configured": "Device is already configured",
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
-      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time."
+      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time.",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   },
   "options": {

--- a/custom_components/renogy/translations/en.json
+++ b/custom_components/renogy/translations/en.json
@@ -8,6 +8,13 @@
           "scan_interval": "Polling interval (seconds)",
           "device_type": "Device Type"
         }
+      },
+      "reconfigure": {
+        "description": "Reconfigure Renogy BLE device: {device_name}. \n\nCurrent device type: {current_device_type}. Changing the device type replaces the entities with the set matching the new type.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)",
+          "device_type": "Device Type"
+        }
       }
     },
     "error": {
@@ -17,7 +24,8 @@
       "already_configured": "Device is already configured",
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
-      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time."
+      "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time.",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   },
   "options": {

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -968,3 +968,58 @@ def test_shunt_poll_keeps_last_good_data_when_library_read_fails():
     call_args = coordinator.device.update_availability.call_args[0]
     assert call_args[0] is False
     assert "history-only payload" in str(call_args[1])
+
+
+def test_model_mismatch_warns_once_for_dcc_model_on_controller_entry():
+    """A DCC model on a controller entry should log a single warning."""
+    ble_module = _load_ble_module()
+    logger = MagicMock()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=logger,
+        address="CC:45:A5:8A:8F:D4",
+        scan_interval=30,
+        device_type="controller",
+    )
+
+    coordinator.data = {"model": "RBC50D1S-G6", "battery_voltage": 13.3}
+    logger.warning.reset_mock()
+
+    coordinator._warn_if_model_mismatch()
+    coordinator._warn_if_model_mismatch()
+
+    logger.warning.assert_called_once()
+    warning_args = logger.warning.call_args[0]
+    assert "RBC50D1S-G6" in warning_args
+    assert "dcc" in warning_args
+
+
+def test_model_mismatch_silent_when_type_matches_or_model_unknown():
+    """Matching or unrecognized models should not produce warnings."""
+    ble_module = _load_ble_module()
+
+    logger = MagicMock()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=logger,
+        address="CC:45:A5:8A:8F:D4",
+        scan_interval=30,
+        device_type="dcc",
+    )
+    coordinator.data = {"model": "RBC50D1S-G6"}
+    logger.warning.reset_mock()
+    coordinator._warn_if_model_mismatch()
+    logger.warning.assert_not_called()
+
+    logger = MagicMock()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=logger,
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    coordinator.data = {"model": "RNG-CTRL-RVR40"}
+    logger.warning.reset_mock()
+    coordinator._warn_if_model_mismatch()
+    logger.warning.assert_not_called()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -66,6 +66,8 @@ def _load_config_flow_module() -> Any:
     class ConfigFlow:
         """Stub ConfigFlow with the methods used by this integration."""
 
+        _reconfigure_entry: Any = None
+
         def __init_subclass__(cls, *, domain: str | None = None, **kwargs: Any) -> None:
             """Accept Home Assistant's domain keyword during subclassing."""
             super().__init_subclass__(**kwargs)
@@ -117,6 +119,25 @@ def _load_config_flow_module() -> Any:
                 "type": "abort",
                 "reason": reason,
                 "description_placeholders": description_placeholders or {},
+            }
+
+        def _get_reconfigure_entry(self) -> Any:
+            """Return the entry under reconfiguration."""
+            return self._reconfigure_entry
+
+        def async_update_reload_and_abort(
+            self,
+            entry: Any,
+            *,
+            data_updates: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            """Apply data updates and abort like Home Assistant does."""
+            entry.data = {**entry.data, **(data_updates or {})}
+            self.last_data_updates = data_updates
+            return {
+                "type": "abort",
+                "reason": "reconfigure_successful",
+                "data_updates": data_updates,
             }
 
     class OptionsFlow:
@@ -267,3 +288,176 @@ def test_manual_entry_keeps_explicit_device_type_override() -> None:
             const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
         },
     }
+
+
+def _make_reconfigure_flow(
+    config_flow_module: Any,
+    const_module: Any,
+    *,
+    data: dict[str, Any],
+    coordinator_model: str | None = None,
+) -> tuple[Any, Any]:
+    """Build a flow + entry pair prepared for reconfiguration."""
+    # A plain namespace stands in for ConfigEntry: the flow only reads
+    # entry_id, title, and data, and the stub update helper reassigns data.
+    entry = types.SimpleNamespace(
+        entry_id="test-entry-id",
+        title="BT-TH-A58A8FD4",
+        data=data,
+    )
+
+    flow = config_flow_module.RenogyConfigFlow()
+    flow._reconfigure_entry = entry
+
+    coordinator_data = {"model": coordinator_model} if coordinator_model else None
+    coordinator = types.SimpleNamespace(data=coordinator_data)
+    flow.hass = types.SimpleNamespace(
+        data={const_module.DOMAIN: {entry.entry_id: {"coordinator": coordinator}}}
+    )
+    return flow, entry
+
+
+def _schema_default(schema: Any, field: str) -> Any:
+    """Return the default value of a voluptuous schema field."""
+    for key in schema.schema:
+        if str(key.schema) == field:
+            return key.default()
+    raise AssertionError(f"Field {field} not found in schema")
+
+
+def test_reconfigure_form_defaults_to_current_entry_values() -> None:
+    """The reconfigure form should preselect the stored type and interval."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, _entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+            "scan_interval": 120,
+        },
+    )
+
+    form_result = asyncio.run(flow.async_step_reconfigure())
+
+    assert form_result["type"] == "form"
+    assert form_result["step_id"] == "reconfigure"
+    assert form_result["description_placeholders"] == {
+        "device_name": "BT-TH-A58A8FD4",
+        "current_device_type": const_module.DeviceType.CONTROLLER.value,
+    }
+    schema = form_result["data_schema"]
+    assert (
+        _schema_default(schema, const_module.CONF_DEVICE_TYPE)
+        == const_module.DeviceType.CONTROLLER.value
+    )
+    assert _schema_default(schema, "scan_interval") == 120
+
+
+def test_reconfigure_form_suggests_dcc_from_reported_model() -> None:
+    """A DCC model reported by the coordinator should preselect the DCC type."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, _entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+        },
+        coordinator_model="RBC50D1S-G6",
+    )
+
+    form_result = asyncio.run(flow.async_step_reconfigure())
+
+    assert form_result["type"] == "form"
+    assert (
+        _schema_default(form_result["data_schema"], const_module.CONF_DEVICE_TYPE)
+        == const_module.DeviceType.DCC.value
+    )
+    # The description still names the currently configured type.
+    assert form_result["description_placeholders"]["current_device_type"] == (
+        const_module.DeviceType.CONTROLLER.value
+    )
+
+
+def test_reconfigure_updates_device_type_and_reloads() -> None:
+    """Submitting the reconfigure form should update entry data in place."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            "address": "CC:45:A5:8A:8F:D4",
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+            "scan_interval": 60,
+        },
+    )
+
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
+                "scan_interval": 60,
+            }
+        )
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {
+        "address": "CC:45:A5:8A:8F:D4",
+        const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
+        "scan_interval": 60,
+    }
+
+
+def test_reconfigure_rejects_unsupported_device_type() -> None:
+    """Unsupported device types should abort with a descriptive reason."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+        },
+    )
+
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                const_module.CONF_DEVICE_TYPE: "hub",
+                "scan_interval": 60,
+            }
+        )
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "unsupported_device_type"
+    assert result["description_placeholders"] == {"device_type": "hub"}
+    assert entry.data[const_module.CONF_DEVICE_TYPE] == (
+        const_module.DeviceType.CONTROLLER.value
+    )
+
+
+def test_reconfigure_form_handles_missing_coordinator() -> None:
+    """A not-yet-loaded entry should fall back to the stored device type."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, _entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
+        },
+    )
+    flow.hass = types.SimpleNamespace(data={})
+
+    form_result = asyncio.run(flow.async_step_reconfigure())
+
+    assert form_result["type"] == "form"
+    assert (
+        _schema_default(form_result["data_schema"], const_module.CONF_DEVICE_TYPE)
+        == const_module.DeviceType.DCC.value
+    )

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -112,3 +112,27 @@ def test_is_device_name_ready_by_device_type() -> None:
     assert not device_name_module.is_device_name_ready(
         "Unknown Renogy Device", const_module.DeviceType.SHUNT300.value
     )
+
+
+def test_detect_device_type_from_model_identifies_dcc_chargers() -> None:
+    """DC-DC charger model strings should map to the DCC device type."""
+    device_name_module = _load_device_name_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+
+    for model in ("DCC50S", "DCC30S", "RBC20D1U", "RBC50D1S-G6", "rbc30d1s"):
+        assert (
+            device_name_module.detect_device_type_from_model(model)
+            == const_module.DeviceType.DCC.value
+        ), model
+
+
+def test_detect_device_type_from_model_ignores_other_models() -> None:
+    """Non-DCC or unusable model strings should not suggest a device type."""
+    device_name_module = _load_device_name_module()
+
+    assert device_name_module.detect_device_type_from_model("RNG-CTRL-RVR40") is None
+    assert device_name_module.detect_device_type_from_model("RBT100LFP12S") is None
+    assert device_name_module.detect_device_type_from_model("RBC1218S0") is None
+    assert device_name_module.detect_device_type_from_model("") is None
+    assert device_name_module.detect_device_type_from_model("   ") is None
+    assert device_name_module.detect_device_type_from_model(None) is None


### PR DESCRIPTION
## Problem

BT-TH modules advertise the same BLE name regardless of the device behind them, so DC-DC chargers (DCC30S/DCC50S, RBC20D1U/RBC50D1S, …) silently default to the `controller` device type at setup. Running a DCC as a controller *appears* to work because the Rover and DCC register maps overlap in the 0x0100 block, but the semantics differ: the alternator/starter-side readings show up mislabeled as "load" values, the discharge-side daily stats read as garbage, and all DCC-only sensors and writable parameters (charge profile, battery type, max charging current) are missing. There is also no way to fix an existing entry short of deleting and re-adding it.

## Changes

- **`detect_device_type_from_model()`** (`device_name.py`): maps device-reported model strings (`DCC*`, `RBC<n>D*`) to the `dcc` device type. The model register is already read on every poll — unlike the BLE name, it can tell a DC-DC charger from a solar controller.
- **One-time mismatch warning** (`ble.py`): when the reported model contradicts the configured device type, log a warning pointing the user at reconfiguration (once per session, no spam).
- **Reconfigure flow** (`config_flow.py`): device type and scan interval can now be changed in place via the standard HA reconfigure UI. The form pre-selects the model-detected type when the coordinator has already read one, and falls back to the stored type otherwise. Uses `async_update_reload_and_abort`, so the entry reloads with the new entity set while the device registry entry (name, area) survives.

## Testing

- 9 new unit tests (model detection matrix, reconfigure form defaults/model suggestion/update/unsupported-type/missing-coordinator paths, mismatch-warning behavior), following the existing stub-based test style; full suite passes (78/78).
- All quality gates clean: `ruff format`, `ruff check`, `ty check`, `pytest`.
- Validated live against an RBC50D1S-G6 ("DCC50S new version") behind a BT-TH module on HA 2026.3: model string reads `RBC50D1S-G6`, detection maps it to `dcc`, and after switching the device type all dynamic data and every parameter register (0xE001, 0xE003–0xE014, 0xE020, 0xE038) read correctly and writes are acknowledged.

## Notes

- The model-prefix list is deliberately conservative (`DCC*`, `RBC<n>D*` — the D marking the DC-input variant); other families keep the current behavior. Happy to extend if you know of models this misses.
- Live testing also surfaced a likely `renogy-ble`-side issue on the RBC50D1S-G6: the discrete `status` read at 0x0120 (8 words) never gets a response, while controller-mode 34-word reads at 0x0100 do return 0x0120–0x0121 content — so `charging_status`/`charging_mode`/`ignition_status`/`output_power`/faults stay unknown on this model. Per the contributing scope split that belongs in `renogy-ble`; I can file an issue there with the details if useful.