### PR TITLE
fix: narrow total power generation value

### DIFF
--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -386,9 +386,9 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda data: (
-            None
-            if data.get(KEY_POWER_GENERATION_TOTAL) is None
-            else data.get(KEY_POWER_GENERATION_TOTAL) / 1000
+            value / 1000
+            if (value := data.get(KEY_POWER_GENERATION_TOTAL)) is not None
+            else None
         ),
     ),
 )


### PR DESCRIPTION
## Summary

- evaluate the total power generation lookup once
- preserve the existing `None` behavior while allowing the value to be narrowed before unit conversion
- unblock the `ty` upgrade in #177

## Root cause

`ty` 0.0.59 no longer treats a `None` check on one `dict.get()` call as narrowing a separate `dict.get()` call. The second lookup therefore remained typed as `Any | None` when divided by `1000`.

## Validation

- `uv run --no-sync ruff format .`
- `uv run --no-sync ruff check . --output-format=github`
- `uvx --from ty==0.0.59 ty check . --output-format=github`
- `uv run --no-sync pytest tests` (`71 passed`)
