### PR TITLE
fix: compose entity names with has_entity_name so device renames cascade

### DIFF
--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -321,6 +321,8 @@ class RenogyNumberEntity(NumberEntity):
     """Representation of a Renogy BLE number entity."""
 
     entity_description: RenogyNumberEntityDescription
+    # Friendly name = device name + entity name, so UI device renames cascade.
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -338,7 +340,7 @@ class RenogyNumberEntity(NumberEntity):
         # Device-dependent properties
         if device:
             self._attr_unique_id = f"{device.address}_{description.key}"
-            self._attr_name = f"{device.name} {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device.address)},
                 name=device.name,
@@ -347,12 +349,19 @@ class RenogyNumberEntity(NumberEntity):
             )
         else:
             self._attr_unique_id = f"{coordinator.address}_{description.key}"
-            self._attr_name = f"Renogy {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, coordinator.address)},
                 name=f"Renogy {device_type.upper()}",
                 manufacturer=ATTR_MANUFACTURER,
             )
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Preserve the legacy entity component before name resolution."""
+        if self._device is None:
+            return f"Renogy {self._attr_name}"
+        return super().suggested_object_id
 
     @property
     def available(self) -> bool:

--- a/custom_components/renogy/select.py
+++ b/custom_components/renogy/select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, cast
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -113,6 +113,8 @@ class RenogyBatteryTypeSelect(SelectEntity):
     """Representation of a Renogy battery type select entity."""
 
     entity_description: SelectEntityDescription
+    # Friendly name = device name + entity name, so UI device renames cascade.
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -131,7 +133,7 @@ class RenogyBatteryTypeSelect(SelectEntity):
         # Device-dependent properties
         if device:
             self._attr_unique_id = f"{device.address}_{description.key}"
-            self._attr_name = f"{device.name} {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device.address)},
                 name=device.name,
@@ -140,12 +142,19 @@ class RenogyBatteryTypeSelect(SelectEntity):
             )
         else:
             self._attr_unique_id = f"{coordinator.address}_{description.key}"
-            self._attr_name = f"Renogy {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, coordinator.address)},
                 name=f"Renogy {device_type.upper()}",
                 manufacturer=ATTR_MANUFACTURER,
             )
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Preserve the legacy entity component before name resolution."""
+        if self._device is None:
+            return f"Renogy {self._attr_name}"
+        return super().suggested_object_id
 
     @property
     def available(self) -> bool:
@@ -251,6 +260,8 @@ class RenogyMaxCurrentSelect(SelectEntity):
     """Representation of a Renogy max charging current select entity."""
 
     entity_description: SelectEntityDescription
+    # Friendly name = device name + entity name, so UI device renames cascade.
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -269,7 +280,7 @@ class RenogyMaxCurrentSelect(SelectEntity):
         # Device-dependent properties
         if device:
             self._attr_unique_id = f"{device.address}_{description.key}"
-            self._attr_name = f"{device.name} {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device.address)},
                 name=device.name,
@@ -278,12 +289,19 @@ class RenogyMaxCurrentSelect(SelectEntity):
             )
         else:
             self._attr_unique_id = f"{coordinator.address}_{description.key}"
-            self._attr_name = f"Renogy {description.name}"
+            self._attr_name = cast("str | None", description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, coordinator.address)},
                 name=f"Renogy {device_type.upper()}",
                 manufacturer=ATTR_MANUFACTURER,
             )
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Preserve the legacy entity component before name resolution."""
+        if self._device is None:
+            return f"Renogy {self._attr_name}"
+        return super().suggested_object_id
 
     @property
     def available(self) -> bool:

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, cast
 
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
@@ -984,6 +984,9 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
 
     entity_description: RenogyBLESensorDescription
     coordinator: RenogyActiveBluetoothCoordinator
+    # Compose the friendly name from the device name so UI device renames
+    # cascade to every entity (HA modern naming model).
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -1015,7 +1018,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
         # Device-dependent properties
         if device:
             self._attr_unique_id = f"{device.address}_{description.key}"
-            self._attr_name = f"{device.name} {description.name}"
+            self._attr_name = cast("str | None", description.name)
 
             # Properly set up device_info for the device registry
             self._attr_device_info = DeviceInfo(
@@ -1030,7 +1033,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
         else:
             # If we don't have a device yet, use coordinator address for unique ID
             self._attr_unique_id = f"{coordinator.address}_{description.key}"
-            self._attr_name = f"Renogy {description.name}"
+            self._attr_name = cast("str | None", description.name)
 
             # Set up basic device info based on coordinator
             self._attr_device_info = DeviceInfo(
@@ -1044,6 +1047,13 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
             )
 
         self._last_updated = None
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Preserve the legacy entity component before name resolution."""
+        if self._device is None:
+            return f"Renogy {self._attr_name}"
+        return super().suggested_object_id
 
     async def async_added_to_hass(self) -> None:
         """Restore monotonic state for synthetic shunt energy totals."""
@@ -1100,7 +1110,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
                 f"{self._device.address}_{self.entity_description.key}"
             )
             # Also update our name
-            self._attr_name = f"{self._device.name} {self.entity_description.name}"
+            self._attr_name = cast("str | None", self.entity_description.name)
 
             # And device_info
             self._attr_device_info = DeviceInfo(
@@ -1229,7 +1239,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
             self._attr_unique_id = (
                 f"{self._device.address}_{self.entity_description.key}"
             )
-            self._attr_name = f"{self._device.name} {self.entity_description.name}"
+            self._attr_name = cast("str | None", self.entity_description.name)
 
         self._last_updated = datetime.now()
 

--- a/custom_components/renogy/switch.py
+++ b/custom_components/renogy/switch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
@@ -76,6 +76,8 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
 
     entity_description: RenogyBLESwitchDescription
     coordinator: RenogyActiveBluetoothCoordinator
+    # Friendly name = device name + entity name, so UI device renames cascade.
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -96,7 +98,7 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
 
         if device:
             self._attr_unique_id = f"{device.address}_{self.entity_description.key}"
-            self._attr_name = f"{device.name} {self.entity_description.name}"
+            self._attr_name = cast("str | None", self.entity_description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, device.address)},
                 name=device.name,
@@ -109,7 +111,7 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
             self._attr_unique_id = (
                 f"{coordinator.address}_{self.entity_description.key}"
             )
-            self._attr_name = f"Renogy {self.entity_description.name}"
+            self._attr_name = cast("str | None", self.entity_description.name)
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, coordinator.address)},
                 name=f"Renogy {device_type.capitalize()}",
@@ -119,6 +121,13 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
                 sw_version=device_type.capitalize(),
             )
 
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Preserve the legacy entity component before name resolution."""
+        if self._device is None:
+            return f"Renogy {self._attr_name}"
+        return super().suggested_object_id
+
     def _update_device_metadata(self, device: RenogyBLEDevice) -> None:
         """Refresh entity metadata from the latest device details."""
         device_model = f"Renogy {self._device_type.capitalize()}"
@@ -126,7 +135,7 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
             device_model = device.parsed_data["model"]
 
         self._attr_unique_id = f"{device.address}_{self.entity_description.key}"
-        self._attr_name = f"{device.name} {self.entity_description.name}"
+        self._attr_name = cast("str | None", self.entity_description.name)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.address)},
             name=device.name,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -56,6 +56,23 @@ def _install_module_stubs() -> None:
     number_module.NumberMode = NumberMode
     sys.modules["homeassistant.components.number"] = number_module
 
+    select_module = cast(Any, types.ModuleType("homeassistant.components.select"))
+
+    class SelectEntity:
+        """Stub select entity base class for testing."""
+
+    @dataclass(frozen=True)
+    class SelectEntityDescription:
+        """Stub select entity description for testing."""
+
+        key: str | None = None
+        name: str | None = None
+        entity_category: str | None = None
+
+    select_module.SelectEntity = SelectEntity
+    select_module.SelectEntityDescription = SelectEntityDescription
+    sys.modules["homeassistant.components.select"] = select_module
+
     config_entries_module = cast(Any, types.ModuleType("homeassistant.config_entries"))
 
     class ConfigEntry:
@@ -162,6 +179,53 @@ def _load_number_module() -> Any:
     sys.modules.pop("custom_components.renogy.number", None)
     sys.modules.pop("custom_components.renogy", None)
     return importlib.import_module("custom_components.renogy.number")
+
+
+def _load_select_module() -> Any:
+    """Load the select module with stubs in place."""
+    _install_module_stubs()
+    sys.modules.pop("custom_components.renogy.select", None)
+    sys.modules.pop("custom_components.renogy", None)
+    return importlib.import_module("custom_components.renogy.select")
+
+
+def test_unresolved_writable_entities_preserve_legacy_object_ids() -> None:
+    """Modern names should retain legacy IDs until the device name resolves."""
+    number_module = _load_number_module()
+    coordinator = MagicMock(address="AA:BB:CC:DD:EE:FF", data={})
+    description = next(
+        item
+        for item in number_module.DCC_OTHER_NUMBERS
+        if item.key == "solar_cutoff_current"
+    )
+    number = number_module.RenogyNumberEntity(
+        coordinator,
+        None,
+        description,
+        number_module.DeviceType.DCC.value,
+    )
+
+    assert number._attr_has_entity_name is True
+    assert number._attr_name == "Solar Cutoff Current"
+    assert number.suggested_object_id == "Renogy Solar Cutoff Current"
+
+    select_module = _load_select_module()
+    selects = (
+        select_module.RenogyBatteryTypeSelect,
+        select_module.RenogyMaxCurrentSelect,
+    )
+    for entity_class, select_description in zip(
+        selects, select_module.DCC_SELECT_ENTITIES, strict=True
+    ):
+        entity = entity_class(
+            coordinator,
+            None,
+            select_description,
+            select_module.DeviceType.DCC.value,
+        )
+        assert entity._attr_has_entity_name is True
+        assert entity._attr_name == select_description.name
+        assert entity.suggested_object_id == f"Renogy {select_description.name}"
 
 
 def test_number_reads_value_directly_from_description_key() -> None:

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -271,6 +271,29 @@ def _read_sensor_value(
     return entity.native_value
 
 
+def test_unresolved_sensor_preserves_legacy_object_id() -> None:
+    """Modern sensor names should retain the unresolved-path legacy ID."""
+    sensor_module = _load_sensor_module()
+    coordinator = MagicMock(
+        address="AA:BB:CC:DD:EE:FF",
+        device=None,
+        data={},
+        last_update_success=True,
+    )
+    description = sensor_module.CONTROLLER_SENSORS[0]
+    entity = sensor_module.RenogyBLESensor(
+        coordinator,
+        None,
+        description,
+        "Battery",
+        sensor_module.DeviceType.CONTROLLER.value,
+    )
+
+    assert entity._attr_has_entity_name is True
+    assert entity._attr_name == description.name
+    assert entity.suggested_object_id == f"Renogy {description.name}"
+
+
 def test_sensor_setup_does_not_wait_for_named_shunt() -> None:
     """Ensure setup skips refresh/wait loop when shunt name is already available."""
     sensor_module = _load_sensor_module()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -249,6 +249,7 @@ def test_switch_updates_metadata_when_coordinator_name_resolves() -> None:
         device=None,
         device_type=switch_module.DeviceType.CONTROLLER.value,
     )
+    assert entity.suggested_object_id == "Renogy DC Load"
     entity.async_write_ha_state = MagicMock()
 
     resolved_device = MagicMock()
@@ -262,7 +263,10 @@ def test_switch_updates_metadata_when_coordinator_name_resolves() -> None:
     entity._handle_coordinator_update()
 
     assert entity._device is resolved_device
-    assert entity._attr_name == "BT-TH-12345 DC Load"
+    # has_entity_name=True: the entity name is just the description name;
+    # HA composes the friendly name from the device name at display time.
+    assert entity._attr_has_entity_name is True
+    assert entity._attr_name == "DC Load"
     assert entity._attr_device_info["name"] == "BT-TH-12345"
     assert entity._attr_device_info["model"] == "Rover 40A"
     entity.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
**Benefit:** Renaming a device in the Home Assistant UI now cascades to all of its entities automatically, matching HA's modern naming model. Cleaner UX, with no `entity_id` changes and manual per-entity name overrides preserved.

## What this changes

Sets `_attr_has_entity_name = True` on all entity classes (sensor, number, select, switch) and reduces `_attr_name` to the entity-specific part instead of hardcoding `"<device name> <entity name>"`. Home Assistant then composes the friendly name as device name + entity name, so a device rename in the UI flows to every one of its entities.

## Tests

All quality gates pass in a single run: `ruff format`, `ruff check`, `ty check`, `pytest` (69 tests).
