### PR TITLE
fix: keep entities available through transient BLE dropouts

### DIFF
--- a/custom_components/renogy/availability.py
+++ b/custom_components/renogy/availability.py
@@ -1,0 +1,45 @@
+"""Shared availability logic for Renogy entities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class CoordinatorAvailability(Protocol):
+    """Coordinator fields used to determine entity availability."""
+
+    @property
+    def device(self) -> DeviceAvailability | None:
+        """Return the coordinator's current device."""
+
+    @property
+    def data(self) -> Mapping[str, Any] | None:
+        """Return the coordinator's cached data."""
+
+
+class DeviceAvailability(Protocol):
+    """Device fields used to determine entity availability."""
+
+    @property
+    def parsed_data(self) -> Mapping[str, Any]:
+        """Return the device's cached parsed data."""
+
+    @property
+    def is_available(self) -> bool:
+        """Return whether the device is within its failure grace."""
+
+
+def is_entity_available(
+    coordinator: CoordinatorAvailability,
+    device: DeviceAvailability | None,
+) -> bool:
+    """Return whether an entity has available cached data within device grace."""
+    current_device = coordinator.device or device
+    if current_device is not None:
+        if not current_device.is_available:
+            return False
+        if current_device.parsed_data:
+            return True
+
+    return bool(coordinator.data)

--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -264,6 +264,9 @@ class RenogyActiveBluetoothCoordinator(
                 self.address,
             )
             self.last_update_success = False
+            if self.device is not None:
+                self.device.update_availability(False, None)
+            self.async_update_listeners()
             return
         if service_info is None:
             self.logger.debug(
@@ -274,7 +277,6 @@ class RenogyActiveBluetoothCoordinator(
 
         try:
             await self._async_poll_device(service_info)
-            self.async_update_listeners()
         except Exception as err:
             self.last_update_success = False
             error_traceback = traceback.format_exc()
@@ -286,6 +288,8 @@ class RenogyActiveBluetoothCoordinator(
             )
             if self.device:
                 self.device.update_availability(False, err)
+
+        self.async_update_listeners()
 
     def async_add_listener(
         self, update_callback: Callable[[], None], context: Any = None
@@ -1088,6 +1092,8 @@ class RenogyActiveBluetoothCoordinator(
         """Handle the device going unavailable."""
         self.logger.info("Device %s is no longer available", service_info.address)
         self.last_update_success = False
+        if self.device is not None:
+            self.device.update_availability(False, None)
         self.async_update_listeners()
 
     @callback

--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .availability import is_entity_available
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
@@ -357,7 +358,7 @@ class RenogyNumberEntity(NumberEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return is_entity_available(self.coordinator, self._device)
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/renogy/select.py
+++ b/custom_components/renogy/select.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .availability import is_entity_available
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
@@ -150,7 +151,7 @@ class RenogyBatteryTypeSelect(SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return is_entity_available(self.coordinator, self._device)
 
     @property
     def current_option(self) -> str | None:
@@ -288,7 +289,7 @@ class RenogyMaxCurrentSelect(SelectEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return self.coordinator.last_update_success
+        return is_entity_available(self.coordinator, self._device)
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -30,6 +30,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
+from .availability import is_entity_available
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
@@ -1119,23 +1120,7 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
     @property
     def available(self) -> bool:
         """Return if the sensor is available."""
-        # Basic coordinator availability check
-        if not self.coordinator.last_update_success:
-            return False
-
-        # Check device availability if we have a device
-        if self._device and not self._device.is_available:
-            return False
-
-        # For the actual data, check either the device's parsed_data or
-        # coordinator's data.
-        data_available = False
-        if self._device and self._device.parsed_data:
-            data_available = True
-        elif self.coordinator.data:
-            data_available = True
-
-        return data_available
+        return is_entity_available(self.coordinator, self._device)
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/renogy/switch.py
+++ b/custom_components/renogy/switch.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .availability import is_entity_available
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
@@ -154,16 +155,7 @@ class RenogyLoadSwitch(PassiveBluetoothCoordinatorEntity, SwitchEntity):
     @property
     def available(self) -> bool:
         """Return if the switch is available."""
-        if not self.coordinator.last_update_success:
-            return False
-
-        if self._device and not self._device.is_available:
-            return False
-
-        if self._device and self._device.parsed_data:
-            return True
-
-        return bool(self.coordinator.data)
+        return is_entity_available(self.coordinator, self._device)
 
     @property
     def is_on(self) -> bool | None:

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,66 @@
+"""Tests for shared Renogy entity availability logic."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+
+def _load_availability_module() -> ModuleType:
+    """Load the standalone helper without importing the integration package."""
+    path = (
+        Path(__file__).parents[1] / "custom_components" / "renogy" / "availability.py"
+    )
+    spec = importlib.util.spec_from_file_location("renogy_availability", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+is_entity_available = _load_availability_module().is_entity_available
+
+
+@pytest.mark.parametrize(
+    ("device", "coordinator_device", "coordinator_data", "expected"),
+    [
+        (None, None, None, False),
+        (None, None, {"battery_voltage": 12.6}, True),
+        (
+            SimpleNamespace(is_available=True, parsed_data={"battery_voltage": 12.6}),
+            None,
+            None,
+            True,
+        ),
+        (
+            SimpleNamespace(is_available=True, parsed_data={}),
+            None,
+            {"battery_voltage": 12.6},
+            True,
+        ),
+        (
+            None,
+            SimpleNamespace(is_available=False, parsed_data={"battery_voltage": 12.6}),
+            {"battery_voltage": 12.6},
+            False,
+        ),
+        (
+            SimpleNamespace(is_available=True, parsed_data={"stale": True}),
+            SimpleNamespace(is_available=False, parsed_data={"battery_voltage": 12.6}),
+            {"battery_voltage": 12.6},
+            False,
+        ),
+    ],
+)
+def test_entity_availability(
+    device: SimpleNamespace | None,
+    coordinator_device: SimpleNamespace | None,
+    coordinator_data: dict[str, Any] | None,
+    expected: bool,
+) -> None:
+    """Availability requires cached data and an available resolved device."""
+    coordinator = SimpleNamespace(data=coordinator_data, device=coordinator_device)
+
+    assert is_entity_available(cast(Any, coordinator), cast(Any, device)) is expected

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -7,6 +7,8 @@ from enum import Enum
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 def _install_module_stubs() -> None:
     """Install minimal module stubs to import the BLE coordinator."""
@@ -195,6 +197,138 @@ def _load_ble_module():
     import importlib
 
     return importlib.import_module("custom_components.renogy.ble")
+
+
+class _GraceDevice:
+    """Device fake with the same consecutive-failure grace contract."""
+
+    def __init__(self, max_failures: int = 3) -> None:
+        self.failure_count = 0
+        self.max_failures = max_failures
+        self.available = True
+        self.parsed_data = {"battery_voltage": 12.6}
+
+    @property
+    def is_available(self) -> bool:
+        """Return whether the failure grace remains."""
+        return self.available and self.failure_count < self.max_failures
+
+    def update_availability(self, success: bool, _error=None) -> None:
+        """Update consecutive failures like RenogyBLEDevice."""
+        if success:
+            self.failure_count = 0
+            self.available = True
+            return
+
+        self.failure_count += 1
+        if self.failure_count >= self.max_failures:
+            self.available = False
+
+
+def test_refresh_without_service_info_exhausts_device_grace() -> None:
+    """Repeated refresh failures must eventually mark cached entities unavailable."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    device = _GraceDevice()
+    coordinator.device = device
+    coordinator.data = dict(device.parsed_data)
+    coordinator._service_info_for_operation = MagicMock(return_value=None)
+    coordinator._can_use_cached_device_without_service_info = MagicMock(
+        return_value=False
+    )
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    for _ in range(2):
+        asyncio.run(coordinator.async_request_refresh())
+        assert device.is_available is True
+
+    asyncio.run(coordinator.async_request_refresh())
+
+    assert device.is_available is False
+    assert coordinator.last_update_success is False
+    assert listener.call_count == 3
+
+
+def test_unavailable_event_updates_device_grace() -> None:
+    """A Bluetooth unavailable event must count toward device failure grace."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    device = _GraceDevice()
+    coordinator.device = device
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-12345",
+        rssi=-60,
+    )
+
+    coordinator._async_handle_unavailable(service_info)
+
+    assert device.failure_count == 1
+    assert coordinator.last_update_success is False
+    listener.assert_called_once_with()
+
+
+def test_refresh_exception_notifies_after_updating_device_grace() -> None:
+    """An unexpected polling error must publish its availability transition."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    device = _GraceDevice(max_failures=1)
+    coordinator.device = device
+    coordinator._service_info_for_operation = MagicMock(return_value=MagicMock())
+    coordinator._async_poll_device = AsyncMock(side_effect=RuntimeError("poll failed"))
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    asyncio.run(coordinator.async_request_refresh())
+
+    assert device.is_available is False
+    assert coordinator.last_update_success is False
+    listener.assert_called_once_with()
+
+
+def test_listener_exception_does_not_update_device_grace() -> None:
+    """A listener bug after a successful poll is not a BLE communication failure."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+    )
+    device = _GraceDevice(max_failures=1)
+    coordinator.device = device
+    coordinator._service_info_for_operation = MagicMock(return_value=MagicMock())
+    coordinator._async_poll_device = AsyncMock(return_value={"battery_voltage": 12.6})
+    coordinator.async_add_listener(MagicMock(side_effect=RuntimeError("listener")))
+
+    with pytest.raises(RuntimeError, match="listener"):
+        asyncio.run(coordinator.async_request_refresh())
+
+    assert device.failure_count == 0
+    assert device.is_available is True
+    assert coordinator.last_update_success is True
 
 
 def test_read_device_data_handles_ble_errors():


### PR DESCRIPTION
**Benefit:** Stops entities from flapping to "unavailable" (and dropping their last reading) on a single missed BLE poll. On wireless links this eliminates the constant gaps in history and momentary unavailable states.

## What this changes

Entity availability now follows the device's failure-grace counter instead of hard-failing on `coordinator.last_update_success`. A single missed poll no longer flips every entity to unavailable; the entity stays available, serving its last cached value, until the device exhausts its grace and is marked unavailable. Applied uniformly to sensor, number, select, and switch entities.

## Tests

All quality gates pass in a single run: `ruff format`, `ruff check`, `ty check`, `pytest` (71 tests).
