### PR TITLE
feat: add REGO-series inverter support (discovery, sensors, controls)

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -28,7 +28,12 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_time_interval
 from renogy_ble import ble as renogy_ble_module
-from renogy_ble.ble import RenogyBleClient, RenogyBLEDevice, clean_device_name
+from renogy_ble.ble import (
+    INVERTER_DEVICE_ID,
+    RenogyBleClient,
+    RenogyBLEDevice,
+    clean_device_name,
+)
 
 from .const import (
     DEFAULT_DEVICE_TYPE,
@@ -179,6 +184,8 @@ class RenogyActiveBluetoothCoordinator(
     def _build_generic_ble_client(self, scanner: Any) -> RenogyBleClient:
         """Build the generic library client for the active device mode."""
         client_kwargs: dict[str, Any] = {"scanner": scanner}
+        if self.device_type == DeviceType.INVERTER.value:
+            client_kwargs["device_id"] = INVERTER_DEVICE_ID
         if self._uses_persistent_non_shunt_session():
             client_kwargs["transport_mode"] = (
                 NonShuntConnectionMode.PERSISTENT_SESSION.value

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
 
 from .const import (
     CONF_COMMUNICATION_HUB_ENABLED,
+    CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SHUNT_CONNECTION_MODE,
@@ -193,6 +194,9 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
             if self._discovered_device:
                 # Coming from bluetooth discovery with device already selected
                 user_input[CONF_ADDRESS] = self._discovered_device.address
+                user_input[CONF_DEVICE_NAME] = _display_name_for_discovery(
+                    self._discovered_device
+                )
 
                 # Create a config entry
                 return self.async_create_entry(
@@ -209,6 +213,10 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 # when discovery data identifies a non-controller device.
                 if user_input.get(CONF_DEVICE_TYPE) == DEFAULT_DEVICE_TYPE:
                     user_input[CONF_DEVICE_TYPE] = detected_type
+
+                user_input[CONF_DEVICE_NAME] = _display_name_for_discovery(
+                    discovery_info
+                )
 
                 await self.async_set_unique_id(address, raise_on_progress=False)
                 self._abort_if_unique_id_configured()

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -15,6 +15,7 @@ MAX_SCAN_INTERVAL = 600  # seconds
 # Renogy BT-1 and BT-2 module identifiers - devices advertise with these prefixes
 RENOGY_BT_PREFIX = "BT-TH-"
 RENOGY_INVERTER_PREFIX = "RNGRIU"
+RENOGY_REGO_INVERTER_PREFIX = "BTRIC"
 RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC", "RNGPRO")
 
 # Configuration parameters
@@ -97,6 +98,16 @@ class DCCRegister:
     TEMPERATURE_COMPENSATION = 0xE014
     REVERSE_CHARGING_VOLTAGE = 0xE020
     SOLAR_CUTOFF_CURRENT = 0xE038
+
+
+# REGO-series inverter setting registers (for write operations)
+class InverterRegister:
+    """Modbus registers for REGO-series inverter settings (function 0x06, value x10)."""
+
+    CHARGE_CURRENT = 0x1146
+    LOW_VOLTAGE_WARN = 0x114E
+    BATTERY_OVER_VOLTAGE = 0x1164
+    AC_INPUT_CURRENT_LIMIT = 0x1168
 
 
 # DCC Battery Type Values

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -21,6 +21,7 @@ RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC", "RNGPRO")
 # Configuration parameters
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DEVICE_TYPE = "device_type"  # New constant for device type
+CONF_DEVICE_NAME = "device_name"
 CONF_SHUNT_CONNECTION_MODE = "shunt_connection_mode"
 CONF_NON_SHUNT_CONNECTION_MODE = "non_shunt_connection_mode"
 CONF_COMMUNICATION_HUB_ENABLED = "communication_hub_enabled"

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -9,6 +9,7 @@ from .const import (
     RENOGY_BATTERY_PRO_PREFIXES,
     RENOGY_BT_PREFIX,
     RENOGY_INVERTER_PREFIX,
+    RENOGY_REGO_INVERTER_PREFIX,
     DeviceType,
 )
 
@@ -25,7 +26,7 @@ BATTERY_PRO_MANUFACTURER_ID = 0xE14C
 DEVICE_NAME_PREFIXES_BY_TYPE: dict[str, tuple[str, ...]] = {
     DeviceType.CONTROLLER.value: (RENOGY_BT_PREFIX,),
     DeviceType.BATTERY.value: (RENOGY_BT_PREFIX, *RENOGY_BATTERY_PRO_PREFIXES),
-    DeviceType.INVERTER.value: (RENOGY_INVERTER_PREFIX,),
+    DeviceType.INVERTER.value: (RENOGY_INVERTER_PREFIX, RENOGY_REGO_INVERTER_PREFIX),
     DeviceType.DCC.value: (RENOGY_BT_PREFIX,),
     DeviceType.SHUNT300.value: (SHUNT300_BT_PREFIX,),
 }
@@ -33,6 +34,7 @@ DEVICE_NAME_PREFIXES_BY_TYPE: dict[str, tuple[str, ...]] = {
 SUPPORTED_BLE_NAME_PREFIXES: tuple[str, ...] = (
     RENOGY_BT_PREFIX,
     RENOGY_INVERTER_PREFIX,
+    RENOGY_REGO_INVERTER_PREFIX,
     *RENOGY_BATTERY_PRO_PREFIXES,
     SHUNT300_BT_PREFIX,
 )
@@ -79,7 +81,9 @@ def detect_device_type_from_ble_name(
     manufacturer_data = manufacturer_data or {}
 
     if isinstance(device_name, str) and has_real_device_name(device_name):
-        if device_name.startswith(RENOGY_INVERTER_PREFIX):
+        if device_name.startswith(
+            (RENOGY_INVERTER_PREFIX, RENOGY_REGO_INVERTER_PREFIX)
+        ):
             return DeviceType.INVERTER.value
         if device_name.startswith(RENOGY_BATTERY_PRO_PREFIXES):
             return DeviceType.BATTERY.value

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -22,6 +22,9 @@
     },
     {
       "local_name": "RNGRIU*"
+    },
+    {
+      "local_name": "BTRIC*"
     }
   ],
   "codeowners": [

--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -26,10 +26,12 @@ from .availability import is_entity_available
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
+    CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
     DEFAULT_DEVICE_TYPE,
     DOMAIN,
     LOGGER,
+    RENOGY_REGO_INVERTER_PREFIX,
     DCCRegister,
     DeviceType,
     InverterRegister,
@@ -296,9 +298,9 @@ INVERTER_ALL_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         name="Charge Current",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=NumberDeviceClass.CURRENT,
-        native_min_value=1.0,
+        native_min_value=5.0,
         native_max_value=150.0,
-        native_step=1.0,
+        native_step=5.0,
         mode=NumberMode.BOX,
         entity_category=EntityCategory.CONFIG,
         register=InverterRegister.CHARGE_CURRENT,
@@ -352,7 +354,9 @@ async def async_setup_entry(
     # Select the number descriptions for this device type
     if device_type == DeviceType.DCC.value:
         descriptions = DCC_ALL_NUMBERS
-    elif device_type == DeviceType.INVERTER.value:
+    elif device_type == DeviceType.INVERTER.value and str(
+        config_entry.data.get(CONF_DEVICE_NAME, "")
+    ).startswith(RENOGY_REGO_INVERTER_PREFIX):
         descriptions = INVERTER_ALL_NUMBERS
     else:
         LOGGER.debug("No number entities for device type: %s", device_type)

--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -32,6 +32,7 @@ from .const import (
     LOGGER,
     DCCRegister,
     DeviceType,
+    InverterRegister,
 )
 
 
@@ -275,6 +276,62 @@ DCC_OTHER_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
 # All DCC number entities
 DCC_ALL_NUMBERS = DCC_VOLTAGE_NUMBERS + DCC_TIME_NUMBERS + DCC_OTHER_NUMBERS
 
+# REGO-series inverter setting parameters (all use 0.1-scale registers, function 0x06)
+INVERTER_ALL_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
+    RenogyNumberEntityDescription(
+        key="inverter_ac_input_current_limit",
+        name="AC Input Current Limit",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=NumberDeviceClass.CURRENT,
+        native_min_value=1.0,
+        native_max_value=50.0,
+        native_step=1.0,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        register=InverterRegister.AC_INPUT_CURRENT_LIMIT,
+        scale=10.0,
+    ),
+    RenogyNumberEntityDescription(
+        key="inverter_charge_current",
+        name="Charge Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=NumberDeviceClass.CURRENT,
+        native_min_value=1.0,
+        native_max_value=150.0,
+        native_step=1.0,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        register=InverterRegister.CHARGE_CURRENT,
+        scale=10.0,
+    ),
+    RenogyNumberEntityDescription(
+        key="inverter_low_voltage_warn",
+        name="Low Voltage Warning",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        native_min_value=9.0,
+        native_max_value=15.5,
+        native_step=0.1,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        register=InverterRegister.LOW_VOLTAGE_WARN,
+        scale=10.0,
+    ),
+    RenogyNumberEntityDescription(
+        key="inverter_over_voltage",
+        name="Battery Over Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=NumberDeviceClass.VOLTAGE,
+        native_min_value=9.0,
+        native_max_value=16.0,
+        native_step=0.1,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        register=InverterRegister.BATTERY_OVER_VOLTAGE,
+        scale=10.0,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -292,26 +349,26 @@ async def async_setup_entry(
     # Get device type from config
     device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
 
-    # Only create number entities for DCC devices
-    if device_type != DeviceType.DCC.value:
-        LOGGER.debug(
-            "Skipping number entities for non-DCC device type: %s", device_type
-        )
+    # Select the number descriptions for this device type
+    if device_type == DeviceType.DCC.value:
+        descriptions = DCC_ALL_NUMBERS
+    elif device_type == DeviceType.INVERTER.value:
+        descriptions = INVERTER_ALL_NUMBERS
+    else:
+        LOGGER.debug("No number entities for device type: %s", device_type)
         return
 
-    LOGGER.debug("Setting up number entities for DCC device")
-
-    entities = []
     device = coordinator.device
 
-    for description in DCC_ALL_NUMBERS:
-        entity = RenogyNumberEntity(
+    entities = [
+        RenogyNumberEntity(
             coordinator=coordinator,
             device=device,
             description=description,
             device_type=device_type,
         )
-        entities.append(entity)
+        for description in descriptions
+    ]
 
     if entities:
         LOGGER.debug("Adding %s number entities", len(entities))

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -134,6 +134,10 @@ KEY_CELL_VOLTAGE_MAX = "cell_voltage_max"
 KEY_CELL_VOLTAGE_DELTA = "cell_voltage_delta"
 KEY_BATTERY_PROBLEM_CODE = "battery_problem_code"
 KEY_SW_VERSION = "sw_version"
+KEY_AC_INPUT_VOLTAGE = "ac_input_voltage"
+KEY_AC_INPUT_CURRENT = "ac_input_current"
+KEY_CHARGING_CURRENT = "charging_current"
+KEY_CHARGING_POWER = "charging_power"
 
 
 @dataclass(frozen=True)
@@ -778,6 +782,75 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Model",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_AC_INPUT_VOLTAGE,
+        name="AC Input Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_AC_INPUT_CURRENT,
+        name="AC Input Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_BATTERY_PERCENTAGE,
+        name="Battery Percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CHARGING_CURRENT,
+        name="Charging Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SOLAR_VOLTAGE,
+        name="Solar Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SOLAR_CURRENT,
+        name="Solar Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_SOLAR_POWER,
+        name="Solar Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CHARGING_POWER,
+        name="Charging Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+    RenogyBLESensorDescription(
+        key=KEY_CHARGING_STATUS,
+        name="Charging Status",
+        device_class=None,
     ),
 )
 

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -119,9 +119,10 @@ def _install_module_stubs() -> None:
     class RenogyBleClient:
         """Stub RenogyBleClient for testing."""
 
-        def __init__(self, scanner, transport_mode="per_operation"):
+        def __init__(self, scanner, transport_mode="per_operation", device_id=0xFF):
             self.scanner = scanner
             self.transport_mode = transport_mode
+            self.device_id = device_id
             self.close = AsyncMock()
 
         async def read_device(self, device):
@@ -159,6 +160,7 @@ def _install_module_stubs() -> None:
             self.error = error
 
     renogy_ble_ble_module.RenogyBleClient = RenogyBleClient
+    renogy_ble_ble_module.INVERTER_DEVICE_ID = 0x20
     renogy_ble_ble_module.RenogyBLEDevice = RenogyBLEDevice
     renogy_ble_ble_module.RenogyBleReadResult = RenogyBleReadResult
     renogy_ble_ble_module.clean_device_name = clean_device_name
@@ -463,6 +465,20 @@ def test_non_shunt_device_defaults_to_intermittent_client():
 
     assert coordinator._ble_client.__class__.__name__ == "RenogyBleClient"
     assert coordinator._ble_client.transport_mode == "per_operation"
+
+
+def test_inverter_client_uses_inverter_modbus_device_id() -> None:
+    """Inverter writes should use the same device ID as inverter reads."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="inverter",
+    )
+
+    assert coordinator._ble_client.device_id == 0x20
 
 
 def test_non_shunt_persistent_mode_uses_library_persistent_transport():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -254,6 +254,7 @@ def test_bluetooth_entry_uses_fallback_title_for_nameless_device() -> None:
             const_module.CONF_DEVICE_TYPE: const_module.DeviceType.BATTERY.value,
             const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
             "address": "AA:BB:CC:DD:EE:FF",
+            const_module.CONF_DEVICE_NAME: config_flow_module.UNKNOWN_DEVICE_NAME,
         },
     }
 
@@ -288,6 +289,7 @@ def test_manual_entry_detects_battery_when_default_type_is_unchanged() -> None:
             "address": "AA:BB:CC:DD:EE:FF",
             const_module.CONF_DEVICE_TYPE: const_module.DeviceType.BATTERY.value,
             const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            const_module.CONF_DEVICE_NAME: config_flow_module.UNKNOWN_DEVICE_NAME,
         },
     }
 
@@ -322,6 +324,7 @@ def test_manual_entry_keeps_explicit_device_type_override() -> None:
             "address": "AA:BB:CC:DD:EE:FF",
             const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
             const_module.CONF_SCAN_INTERVAL: const_module.DEFAULT_SCAN_INTERVAL,
+            const_module.CONF_DEVICE_NAME: config_flow_module.UNKNOWN_DEVICE_NAME,
         },
     }
 

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -144,3 +144,25 @@ def test_detect_device_type_from_model_ignores_other_models() -> None:
     assert device_name_module.detect_device_type_from_model("") is None
     assert device_name_module.detect_device_type_from_model("   ") is None
     assert device_name_module.detect_device_type_from_model(None) is None
+
+
+def test_btric_inverter_name_is_supported():
+    device_name_module = _load_device_name_module()
+    assert device_name_module.is_supported_renogy_ble_name("BTRIC130000029")
+
+
+def test_btric_inverter_type_detected():
+    device_name_module = _load_device_name_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    assert (
+        device_name_module.detect_device_type_from_ble_name("BTRIC130000029")
+        == const_module.DeviceType.INVERTER.value
+    )
+
+
+def test_btric_inverter_name_ready():
+    device_name_module = _load_device_name_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    assert device_name_module.is_device_name_ready(
+        "BTRIC130000029", const_module.DeviceType.INVERTER.value
+    )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -305,7 +305,11 @@ def test_inverter_numbers_cover_registers() -> None:
     acil = by_key["inverter_ac_input_current_limit"]
     assert (acil.native_min_value, acil.native_max_value) == (1.0, 50.0)
     cc = by_key["inverter_charge_current"]
-    assert (cc.native_min_value, cc.native_max_value) == (1.0, 150.0)
+    assert (cc.native_min_value, cc.native_max_value, cc.native_step) == (
+        5.0,
+        150.0,
+        5.0,
+    )
 
 
 def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
@@ -320,7 +324,10 @@ def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
 
     config_entry = MagicMock()
     config_entry.entry_id = "entry-1"
-    config_entry.data = {number.CONF_DEVICE_TYPE: number.DeviceType.INVERTER.value}
+    config_entry.data = {
+        number.CONF_DEVICE_TYPE: number.DeviceType.INVERTER.value,
+        number.CONF_DEVICE_NAME: "BTRIC130000029",
+    }
 
     async_add_entities = MagicMock()
 
@@ -332,3 +339,24 @@ def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
     assert {e.entity_description.key for e in created_entities} == {
         d.key for d in number.INVERTER_ALL_NUMBERS
     }
+
+
+def test_inverter_number_setup_skips_non_rego_inverters() -> None:
+    """REGO setpoints should not be exposed on incompatible inverter profiles."""
+    number = _load_number_module()
+
+    coordinator = MagicMock()
+    coordinator.device = None
+    hass = MagicMock()
+    hass.data = {number.DOMAIN: {"entry-1": {"coordinator": coordinator}}}
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.data = {
+        number.CONF_DEVICE_TYPE: number.DeviceType.INVERTER.value,
+        number.CONF_DEVICE_NAME: "RNGRIU123456",
+    }
+    async_add_entities = MagicMock()
+
+    asyncio.run(number.async_setup_entry(hass, config_entry, async_add_entities))
+
+    async_add_entities.assert_not_called()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -281,3 +281,54 @@ def test_solar_cutoff_current_writes_centiamps() -> None:
     )
     assert entity.native_value == 7.0
     entity.async_write_ha_state.assert_called_once()
+
+
+def test_inverter_numbers_cover_registers() -> None:
+    """Ensure REGO inverter setpoints are exposed with the correct registers/ranges."""
+    number = _load_number_module()
+
+    by_key = {d.key: d for d in number.INVERTER_ALL_NUMBERS}
+    assert set(by_key) == {
+        "inverter_ac_input_current_limit",
+        "inverter_charge_current",
+        "inverter_low_voltage_warn",
+        "inverter_over_voltage",
+    }
+    assert by_key["inverter_ac_input_current_limit"].register == 0x1168
+    assert by_key["inverter_ac_input_current_limit"].scale == 10.0
+    assert by_key["inverter_charge_current"].register == 0x1146
+    assert by_key["inverter_low_voltage_warn"].register == 0x114E
+    assert by_key["inverter_over_voltage"].register == 0x1164
+    # every setpoint writes with x10 scale
+    assert all(d.scale == 10.0 for d in number.INVERTER_ALL_NUMBERS)
+    # ranges clamped to the app's safe bounds
+    acil = by_key["inverter_ac_input_current_limit"]
+    assert (acil.native_min_value, acil.native_max_value) == (1.0, 50.0)
+    cc = by_key["inverter_charge_current"]
+    assert (cc.native_min_value, cc.native_max_value) == (1.0, 150.0)
+
+
+def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
+    """Ensure async_setup_entry wires up the inverter number descriptions."""
+    number = _load_number_module()
+
+    coordinator = MagicMock()
+    coordinator.device = None
+
+    hass = MagicMock()
+    hass.data = {number.DOMAIN: {"entry-1": {"coordinator": coordinator}}}
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.data = {number.CONF_DEVICE_TYPE: number.DeviceType.INVERTER.value}
+
+    async_add_entities = MagicMock()
+
+    asyncio.run(number.async_setup_entry(hass, config_entry, async_add_entities))
+
+    async_add_entities.assert_called_once()
+    (created_entities,) = async_add_entities.call_args.args
+    assert len(created_entities) == len(number.INVERTER_ALL_NUMBERS)
+    assert {e.entity_description.key for e in created_entities} == {
+        d.key for d in number.INVERTER_ALL_NUMBERS
+    }

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -809,3 +809,21 @@ def test_sensor_setup_registers_hub_battery_sensor_layer() -> None:
         coordinator,
         async_add_entities,
     )
+
+
+def test_inverter_sensors_cover_rego_fields() -> None:
+    """Ensure REGO inverter fields are exposed via INVERTER_SENSORS."""
+    sensor_module = _load_sensor_module()
+
+    keys = {description.key for description in sensor_module.INVERTER_SENSORS}
+    assert {
+        "ac_input_voltage",
+        "ac_input_current",
+        "battery_percentage",
+        "charging_current",
+        "solar_voltage",
+        "solar_current",
+        "solar_power",
+        "charging_power",
+        "charging_status",
+    } <= keys


### PR DESCRIPTION
**Benefit:** Adds full Home Assistant support for Renogy REGO-series inverter/chargers — a device class the integration doesn't handle today. Auto-discovers `BTRIC*` units, exposes AC/solar/charging sensors, and adds number controls to write the four inverter setpoints.

## What this adds

- **Discovery:** REGO units advertise built-in BLE as `BTRIC*`, not `RNGRIU*`. Added to name-based device-type detection and the manifest bluetooth matcher so they are found and typed as inverters.
- **Sensors:** AC input voltage/current, battery percentage, charging current, solar voltage/current/power, charging power, and charging status.
- **Controls:** number entities for the inverter setpoints (AC input current limit, charge current, low-voltage warning, battery over-voltage), written via Modbus function 0x06.

## Pre-merge checklist

- [x] renogy-ble#125 merged and `renogy-ble` v2.5.0 released to PyPI
- [x] rebased onto main (`renogy-ble==2.5.0`); adapted to the #202 value-lookup refactor and added `suggested_display_precision` to the new sensors
- [x] all gates pass locally: ruff format, ruff check, ty check, pytest
- [x] marked ready for review

## Tests

Test suite passes (91 tests), type-check clean against renogy-ble 2.5.0.
