### PR TITLE
feat: expose and apply poll interval, failure grace, and reconnect interval

### DIFF
--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -13,14 +13,18 @@ from homeassistant.helpers.device_registry import async_get as async_get_device_
 from .const import (
     CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
+    CONF_MAX_FAILURES,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SCAN_INTERVAL,
     CONF_SHUNT_CONNECTION_MODE,
+    CONF_UNAVAILABLE_RETRY_INTERVAL,
     DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_MAX_FAILURES,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SHUNT_CONNECTION_MODE,
+    DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
     DOMAIN,
     LOGGER,
     DeviceType,
@@ -47,8 +51,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     LOGGER.info("Setting up Renogy BLE integration with entry %s", entry.entry_id)
 
-    # Get configuration from entry
-    scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    # Get configuration from entry. Runtime knobs resolve options → data →
+    # default so that edits made in the options flow take effect on reload.
+    scan_interval = _resolve_setting(entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    max_failures = _resolve_setting(entry, CONF_MAX_FAILURES, DEFAULT_MAX_FAILURES)
+    unavailable_retry_interval = _resolve_setting(
+        entry, CONF_UNAVAILABLE_RETRY_INTERVAL, DEFAULT_UNAVAILABLE_RETRY_INTERVAL
+    )
     device_address = entry.data.get(CONF_ADDRESS)
     device_type = entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
     shunt_connection_mode = _get_shunt_connection_mode(entry)
@@ -85,6 +94,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_type=device_type,
             shunt_connection_mode=shunt_connection_mode,
             non_shunt_connection_mode=non_shunt_connection_mode,
+            max_failures=max_failures,
+            unavailable_retry_interval=unavailable_retry_interval,
             device_data_callback=device_data_callback,
             communication_hub_enabled=True,
         )
@@ -97,9 +108,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_type=device_type,
             shunt_connection_mode=shunt_connection_mode,
             non_shunt_connection_mode=non_shunt_connection_mode,
+            max_failures=max_failures,
+            unavailable_retry_interval=unavailable_retry_interval,
             device_data_callback=device_data_callback,
         )
-
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
     # Store coordinator and devices in hass.data
@@ -128,6 +140,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.async_create_task(coordinator.async_request_refresh())
 
     return True
+
+
+def _resolve_setting(entry: ConfigEntry, key: str, default: int) -> int:
+    """Resolve a setting from options, then data, then the given default."""
+    return entry.options.get(key, entry.data.get(key, default))
 
 
 def _get_shunt_connection_mode(entry: ConfigEntry) -> str:

--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -32,9 +32,11 @@ from renogy_ble.ble import RenogyBleClient, RenogyBLEDevice, clean_device_name
 
 from .const import (
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_MAX_FAILURES,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SHUNT_CONNECTION_MODE,
+    DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
     DeviceType,
     NonShuntConnectionMode,
     ShuntConnectionMode,
@@ -106,6 +108,8 @@ class RenogyActiveBluetoothCoordinator(
         device_type: str = DEFAULT_DEVICE_TYPE,
         shunt_connection_mode: str = DEFAULT_SHUNT_CONNECTION_MODE,
         non_shunt_connection_mode: str = DEFAULT_NON_SHUNT_CONNECTION_MODE,
+        max_failures: int = DEFAULT_MAX_FAILURES,
+        unavailable_retry_interval: int = DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
         device_data_callback: Callable[[RenogyBLEDevice], Awaitable[None]]
         | None = None,
     ):
@@ -123,6 +127,8 @@ class RenogyActiveBluetoothCoordinator(
         self.scan_interval = scan_interval
         self.shunt_connection_mode = shunt_connection_mode
         self.non_shunt_connection_mode = non_shunt_connection_mode
+        self.max_failures = max_failures
+        self.unavailable_retry_interval = unavailable_retry_interval
         self.device_type = device_type
         self.last_poll_time: datetime | None = None
         self.device_data_callback = device_data_callback
@@ -258,14 +264,13 @@ class RenogyActiveBluetoothCoordinator(
             service_info is None
             and not self._can_use_cached_device_without_service_info()
         ):
+            error = RuntimeError(f"No service info available for device {self.address}")
             self.logger.error(
                 "No service info available for device %s. Ensure device is within "
                 "range and powered on.",
                 self.address,
             )
-            self.last_update_success = False
-            if self.device is not None:
-                self.device.update_availability(False, None)
+            self._record_poll_availability(False, error)
             self.async_update_listeners()
             return
         if service_info is None:
@@ -278,7 +283,6 @@ class RenogyActiveBluetoothCoordinator(
         try:
             await self._async_poll_device(service_info)
         except Exception as err:
-            self.last_update_success = False
             error_traceback = traceback.format_exc()
             self.logger.debug(
                 "Error refreshing device %s: %s\n%s",
@@ -286,8 +290,7 @@ class RenogyActiveBluetoothCoordinator(
                 str(err),
                 error_traceback,
             )
-            if self.device:
-                self.device.update_availability(False, err)
+            self._record_poll_availability(False, err)
 
         self.async_update_listeners()
 
@@ -309,6 +312,19 @@ class RenogyActiveBluetoothCoordinator(
         """Update all registered listeners."""
         for update_callback in self._update_listeners:
             update_callback()
+
+    def _record_poll_availability(
+        self, success: bool, error: Exception | None = None
+    ) -> None:
+        """Apply one poll result while honoring the device failure threshold."""
+        if self.device is None:
+            self.last_update_success = success
+            return
+
+        self.device.update_availability(success, error)
+        # Keep coordinator success tied to the most recent operation. Entity
+        # availability is resolved separately from the device's failure grace.
+        self.last_update_success = success
 
     def _schedule_refresh(self) -> None:
         """Schedule a refresh with the update interval."""
@@ -437,6 +453,8 @@ class RenogyActiveBluetoothCoordinator(
                 service_info.advertisement.rssi,
                 device_type=detected_type,
                 manufacturer_data=manufacturer_data,
+                max_failures=self.max_failures,
+                unavailable_retry_interval=self.unavailable_retry_interval,
             )
         else:
             old_name = self.device.name
@@ -610,9 +628,13 @@ class RenogyActiveBluetoothCoordinator(
         stale = (
             now - self._last_sustained_shunt_push >= SHUNT_FORCE_UPDATE_INTERVAL_SECONDS
         )
+        was_available = self.last_update_success
+        self._record_poll_availability(True)
         # Keep the recovery path alive after a transient listener failure even
         # when the first restored payload matches the previous values.
-        if not changed and not stale and self.last_update_success:
+        if not changed and not stale:
+            if not was_available and self.last_update_success:
+                self.hass.loop.call_soon_threadsafe(self.async_update_listeners)
             return True
 
         if self.device is not None:
@@ -623,7 +645,6 @@ class RenogyActiveBluetoothCoordinator(
             )
             existing_data.update(parsed_data)
             self.device.parsed_data = existing_data
-            self.device.update_availability(True, None)
 
         current_data = dict(self.data) if isinstance(self.data, dict) else {}
         current_data.update(parsed_data)
@@ -814,6 +835,13 @@ class RenogyActiveBluetoothCoordinator(
                     continue
 
                 self._update_device_from_service_info(service_info)
+                if self.device is not None and not self.device.should_retry_connection:
+                    self.logger.debug(
+                        "Smart Shunt %s is in its unavailable reconnect cooldown",
+                        self.address,
+                    )
+                    await asyncio.sleep(SHUNT_RECONNECT_DELAY_SECONDS)
+                    continue
                 connect_device = await self._async_prepare_shunt_reconnect(
                     service_info.device
                 )
@@ -854,9 +882,7 @@ class RenogyActiveBluetoothCoordinator(
                     self._schedule_shunt_disconnect(client)
                 return
             except Exception as err:
-                self.last_update_success = False
-                if self.device is not None:
-                    self.device.update_availability(False, err)
+                self._record_poll_availability(False, err)
                 self.hass.loop.call_soon_threadsafe(self.async_update_listeners)
                 self.logger.debug(
                     "Smart Shunt listener error for %s: %s",
@@ -926,9 +952,8 @@ class RenogyActiveBluetoothCoordinator(
                     if error is not None and not isinstance(error, Exception):
                         error = Exception(str(error))
 
-                # Always update the device availability and last_update_success
-                device.update_availability(success, error)
-                self.last_update_success = success
+                # Keep entities available until the configured failure threshold.
+                self._record_poll_availability(success, error)
 
                 # Update coordinator data if successful
                 if success and device.parsed_data:
@@ -1049,6 +1074,13 @@ class RenogyActiveBluetoothCoordinator(
             return self.data if isinstance(self.data, dict) else {}
 
         self.last_poll_time = datetime.now()
+        if self.device is not None and not self.device.should_retry_connection:
+            self.logger.debug(
+                "Skipping poll for %s during unavailable reconnect cooldown",
+                self.address,
+            )
+            return self.data if isinstance(self.data, dict) else {}
+
         if service_info is not None:
             self.logger.debug(
                 "Polling device: %s (%s)", service_info.name, service_info.address
@@ -1082,7 +1114,6 @@ class RenogyActiveBluetoothCoordinator(
                 service_info.address if service_info is not None else self.address
             )
             self.logger.info("Failed to retrieve data from %s", failed_address)
-            self.last_update_success = False
             return self.data if isinstance(self.data, dict) else {}
 
     @callback
@@ -1091,9 +1122,10 @@ class RenogyActiveBluetoothCoordinator(
     ) -> None:
         """Handle the device going unavailable."""
         self.logger.info("Device %s is no longer available", service_info.address)
-        self.last_update_success = False
-        if self.device is not None:
-            self.device.update_availability(False, None)
+        self._record_poll_availability(
+            False,
+            RuntimeError(f"Bluetooth device {service_info.address} is unavailable"),
+        )
         self.async_update_listeners()
 
     @callback

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -20,18 +20,26 @@ from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
 from .const import (
     CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
+    CONF_MAX_FAILURES,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SHUNT_CONNECTION_MODE,
+    CONF_UNAVAILABLE_RETRY_INTERVAL,
     DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_MAX_FAILURES,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SHUNT_CONNECTION_MODE,
+    DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
     DEVICE_TYPES,
     DOMAIN,
     LOGGER,
+    MAX_MAX_FAILURES,
     MAX_SCAN_INTERVAL,
+    MAX_UNAVAILABLE_RETRY_INTERVAL,
+    MIN_MAX_FAILURES,
     MIN_SCAN_INTERVAL,
+    MIN_UNAVAILABLE_RETRY_INTERVAL,
     NON_SHUNT_CONNECTION_MODES,
     SHUNT_CONNECTION_MODES,
     SUPPORTED_DEVICE_TYPES,
@@ -80,19 +88,69 @@ def _detect_device_type_for_discovery(discovery_info: BluetoothServiceInfoBleak)
     )
 
 
-def _build_shunt_options_schema(default_mode: str) -> vol.Schema:
+def _resolve_option(config_entry: ConfigEntry, key: str, default: Any) -> Any:
+    """Resolve a setting from options, then data, then the given default."""
+    return config_entry.options.get(key, config_entry.data.get(key, default))
+
+
+def _runtime_options_schema_dict(config_entry: ConfigEntry) -> dict[Any, Any]:
+    """Build the shared runtime knobs (poll interval, grace, reconnect interval).
+
+    Each field is pre-filled from options → data → default and range-validated.
+    """
+    return {
+        vol.Optional(
+            CONF_SCAN_INTERVAL,
+            default=_resolve_option(
+                config_entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            ),
+        ): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+        ),
+        vol.Optional(
+            CONF_MAX_FAILURES,
+            default=_resolve_option(
+                config_entry, CONF_MAX_FAILURES, DEFAULT_MAX_FAILURES
+            ),
+        ): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=MIN_MAX_FAILURES, max=MAX_MAX_FAILURES),
+        ),
+        vol.Optional(
+            CONF_UNAVAILABLE_RETRY_INTERVAL,
+            default=_resolve_option(
+                config_entry,
+                CONF_UNAVAILABLE_RETRY_INTERVAL,
+                DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
+            ),
+        ): vol.All(
+            vol.Coerce(int),
+            vol.Range(
+                min=MIN_UNAVAILABLE_RETRY_INTERVAL,
+                max=MAX_UNAVAILABLE_RETRY_INTERVAL,
+            ),
+        ),
+    }
+
+
+def _build_shunt_options_schema(
+    config_entry: ConfigEntry, default_mode: str
+) -> vol.Schema:
     """Build the Smart Shunt options schema."""
     return vol.Schema(
         {
             vol.Required(
                 CONF_SHUNT_CONNECTION_MODE,
                 default=default_mode,
-            ): vol.In(SHUNT_CONNECTION_MODES)
+            ): vol.In(SHUNT_CONNECTION_MODES),
+            **_runtime_options_schema_dict(config_entry),
         }
     )
 
 
 def _build_non_shunt_options_schema(
+    config_entry: ConfigEntry,
     default_mode: str,
     default_hub_enabled: bool,
 ) -> vol.Schema:
@@ -107,6 +165,7 @@ def _build_non_shunt_options_schema(
                 CONF_COMMUNICATION_HUB_ENABLED,
                 default=default_hub_enabled,
             ): bool,
+            **_runtime_options_schema_dict(config_entry),
         }
     )
 
@@ -289,19 +348,23 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                     description_placeholders={"device_type": device_type},
                 )
 
+            scan_interval = user_input[CONF_SCAN_INTERVAL]
             return self.async_update_reload_and_abort(
                 entry,
                 data_updates={
                     CONF_DEVICE_TYPE: device_type,
-                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
+                    CONF_SCAN_INTERVAL: scan_interval,
                 },
+                options={**entry.options, CONF_SCAN_INTERVAL: scan_interval},
             )
 
         current_type = entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
         suggested_type = (
             self._detect_device_type_from_coordinator(entry) or current_type
         )
-        current_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        current_interval = _resolve_option(
+            entry, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
 
         reconfigure_schema = vol.Schema(
             {
@@ -382,7 +445,9 @@ class RenogyOptionsFlowHandler(OptionsFlow):
             )
             return self.async_show_form(
                 step_id="init",
-                data_schema=_build_shunt_options_schema(current_mode),
+                data_schema=_build_shunt_options_schema(
+                    self._config_entry, current_mode
+                ),
             )
 
         if user_input is not None:
@@ -399,6 +464,7 @@ class RenogyOptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="init",
             data_schema=_build_non_shunt_options_schema(
+                self._config_entry,
                 current_mode,
                 current_hub_enabled,
             ),

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -12,6 +12,18 @@ DEFAULT_SCAN_INTERVAL = 60  # seconds
 MIN_SCAN_INTERVAL = 10  # seconds
 MAX_SCAN_INTERVAL = 600  # seconds
 
+# Availability grace: consecutive failed polls tolerated before the device is
+# marked unavailable. Default matches RenogyBLEDevice.max_failures.
+DEFAULT_MAX_FAILURES = 3
+MIN_MAX_FAILURES = 1
+MAX_MAX_FAILURES = 10
+
+# Reconnect cooldown (minutes) before retrying a fully-unavailable device.
+# Default matches renogy_ble's UNAVAILABLE_RETRY_INTERVAL.
+DEFAULT_UNAVAILABLE_RETRY_INTERVAL = 10  # minutes
+MIN_UNAVAILABLE_RETRY_INTERVAL = 1  # minutes
+MAX_UNAVAILABLE_RETRY_INTERVAL = 60  # minutes
+
 # Renogy BT-1 and BT-2 module identifiers - devices advertise with these prefixes
 RENOGY_BT_PREFIX = "BT-TH-"
 RENOGY_INVERTER_PREFIX = "RNGRIU"
@@ -19,6 +31,8 @@ RENOGY_BATTERY_PRO_PREFIXES = ("RNGRBP", "RNGC", "RNGPRO")
 
 # Configuration parameters
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_MAX_FAILURES = "max_failures"
+CONF_UNAVAILABLE_RETRY_INTERVAL = "unavailable_retry_interval"
 CONF_DEVICE_TYPE = "device_type"  # New constant for device type
 CONF_SHUNT_CONNECTION_MODE = "shunt_connection_mode"
 CONF_NON_SHUNT_CONNECTION_MODE = "non_shunt_connection_mode"

--- a/custom_components/renogy/strings.json
+++ b/custom_components/renogy/strings.json
@@ -34,7 +34,10 @@
         "data": {
           "shunt_connection_mode": "Smart Shunt connection mode",
           "non_shunt_connection_mode": "Non-shunt connection mode",
-          "communication_hub_enabled": "Communication Hub / multiple batteries"
+          "communication_hub_enabled": "Communication Hub / multiple batteries",
+          "scan_interval": "Polling interval (seconds)",
+          "max_failures": "Failed polls before unavailable",
+          "unavailable_retry_interval": "Reconnect interval while unavailable (minutes)"
         }
       }
     }

--- a/custom_components/renogy/translations/en.json
+++ b/custom_components/renogy/translations/en.json
@@ -34,7 +34,10 @@
         "data": {
           "shunt_connection_mode": "Smart Shunt connection mode",
           "non_shunt_connection_mode": "Non-shunt connection mode",
-          "communication_hub_enabled": "Communication Hub / multiple batteries"
+          "communication_hub_enabled": "Communication Hub / multiple batteries",
+          "scan_interval": "Polling interval (seconds)",
+          "max_failures": "Failed polls before unavailable",
+          "unavailable_retry_interval": "Reconnect interval while unavailable (minutes)"
         }
       }
     }

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -136,6 +136,8 @@ def _install_module_stubs() -> None:
             advertisement_rssi,
             device_type=None,
             manufacturer_data=None,
+            max_failures=3,
+            unavailable_retry_interval=10,
         ):
             self.ble_device = ble_device
             self.address = ble_device.address
@@ -143,8 +145,24 @@ def _install_module_stubs() -> None:
             self.rssi = advertisement_rssi
             self.device_type = device_type
             self.manufacturer_data = manufacturer_data or {}
+            self.max_failures = max_failures
+            self.unavailable_retry_interval = unavailable_retry_interval
             self.parsed_data = {}
-            self.update_availability = MagicMock()
+            self.failure_count = 0
+            self.is_available = True
+            self.should_retry_connection = True
+
+            def _update_availability(success, _error=None):
+                if success:
+                    self.failure_count = 0
+                    self.is_available = True
+                    return
+
+                self.failure_count += 1
+                if self.failure_count >= self.max_failures:
+                    self.is_available = False
+
+            self.update_availability = MagicMock(side_effect=_update_availability)
 
     def clean_device_name(name: str) -> str:
         """Return a cleaned device name for testing."""
@@ -358,10 +376,40 @@ def test_read_device_data_handles_ble_errors():
 
     assert success is False
     assert coordinator.last_update_success is False
+    assert coordinator.device.is_available is True
     coordinator.device.update_availability.assert_called_once()
     call_args = coordinator.device.update_availability.call_args[0]
     assert call_args[0] is False
     assert "read failed" in str(call_args[1])
+
+
+def test_read_failures_respect_configured_availability_grace():
+    """Entities stay available until the configured failure threshold is reached."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        max_failures=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-12345",
+        rssi=-60,
+    )
+    coordinator._ble_client.read_device = AsyncMock(
+        side_effect=ble_module.BleakError("read failed")
+    )
+
+    assert asyncio.run(coordinator._read_device_data(service_info)) is False
+    assert coordinator.last_update_success is False
+    assert coordinator.device.is_available is True
+
+    assert asyncio.run(coordinator._read_device_data(service_info)) is False
+    assert coordinator.last_update_success is False
+    assert coordinator.device.is_available is False
 
 
 def test_sustained_shunt_device_defaults_to_generic_client():
@@ -401,6 +449,56 @@ def test_update_device_detects_battery_from_manufacturer_data_only():
     assert coordinator.device_type == "battery"
     assert device.device_type == "battery"
     assert device.manufacturer_data == {0xE14C: b"\x01"}
+
+
+def test_update_device_applies_configured_grace_and_reconnect_interval():
+    """The coordinator constructs the device with its grace/reconnect settings."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        max_failures=5,
+        unavailable_retry_interval=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-123456",
+        rssi=-60,
+    )
+
+    device = coordinator._update_device_from_service_info(service_info)
+
+    assert device.max_failures == 5
+    assert device.unavailable_retry_interval == 2
+
+
+def test_poll_skips_connection_during_unavailable_retry_cooldown():
+    """An unavailable intermittent device should not reconnect before cooldown."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        unavailable_retry_interval=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-123456",
+        rssi=-60,
+    )
+    coordinator._update_device_from_service_info(service_info)
+    coordinator.device.should_retry_connection = False
+    coordinator._ble_client.read_device = AsyncMock()
+
+    result = asyncio.run(coordinator._async_poll_device(service_info))
+
+    assert result == {}
+    coordinator._ble_client.read_device.assert_not_awaited()
 
 
 def test_update_device_preserves_cached_manufacturer_data() -> None:
@@ -569,6 +667,62 @@ def test_refresh_without_service_info_still_fails_without_cached_device():
     logger.error.assert_called_once()
 
 
+def test_missing_service_info_respects_configured_availability_grace():
+    """Advertisement loss should count toward the same configured threshold."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        max_failures=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-12345",
+        rssi=-60,
+    )
+    coordinator._update_device_from_service_info(service_info)
+    ble_module.bluetooth.async_last_service_info.return_value = None
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    asyncio.run(coordinator.async_request_refresh())
+    assert coordinator.last_update_success is False
+    assert coordinator.device.is_available is True
+
+    asyncio.run(coordinator.async_request_refresh())
+    assert coordinator.last_update_success is False
+    assert listener.call_count == 2
+
+
+def test_bluetooth_unavailable_event_respects_configured_grace():
+    """Bluetooth unavailable events should honor the failure threshold."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        max_failures=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-12345",
+        rssi=-60,
+    )
+    coordinator._update_device_from_service_info(service_info)
+
+    coordinator._async_handle_unavailable(service_info)
+    assert coordinator.last_update_success is False
+    assert coordinator.device.is_available is True
+
+    coordinator._async_handle_unavailable(service_info)
+    assert coordinator.last_update_success is False
+
+
 def test_read_device_data_uses_cached_device_without_service_info():
     """Ensure reads can reuse the cached BLE device for persistent sessions."""
     ble_module = _load_ble_module()
@@ -730,8 +884,14 @@ def test_sustained_shunt_notification_recovers_from_duplicate_payload_after_erro
         scan_interval=30,
         device_type="shunt300",
         shunt_connection_mode="sustained",
+        max_failures=1,
     )
-    coordinator.device = MagicMock(parsed_data={})
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="RTMShunt300A1B2",
+        rssi=-60,
+    )
+    coordinator._update_device_from_service_info(service_info)
     listener = MagicMock()
     coordinator.async_add_listener(listener)
 
@@ -748,10 +908,12 @@ def test_sustained_shunt_notification_recovers_from_duplicate_payload_after_erro
 
     with patch.object(ble_module.time, "monotonic", side_effect=[100.0, 110.0]):
         coordinator._process_sustained_shunt_notification(b"first")
-        coordinator.last_update_success = False
+        coordinator._record_poll_availability(False, RuntimeError("disconnected"))
+        assert coordinator.device.failure_count == 1
         coordinator._process_sustained_shunt_notification(b"second")
 
     assert coordinator.last_update_success is True
+    assert coordinator.device.failure_count == 0
     assert listener.call_count == 2
     assert coordinator.device.update_availability.call_args_list[-1][0] == (True, None)
 
@@ -865,6 +1027,7 @@ def test_sustained_shunt_listener_error_notifies_entities():
         scan_interval=30,
         device_type="shunt300",
         shunt_connection_mode="sustained",
+        max_failures=1,
     )
     listener = MagicMock()
     coordinator.async_add_listener(listener)
@@ -896,6 +1059,40 @@ def test_sustained_shunt_listener_error_notifies_entities():
     )
     assert listener.call_count == 1
     assert client.disconnect.await_count == 1
+
+
+def test_sustained_shunt_respects_unavailable_retry_cooldown():
+    """A sustained shunt should not reconnect before its cooldown expires."""
+    ble_module = _load_ble_module()
+    hass = MagicMock()
+    hass.state = ble_module.CoreState.running
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=hass,
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="shunt300",
+        shunt_connection_mode="sustained",
+        unavailable_retry_interval=2,
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="RTMShunt300A1B2",
+        rssi=-60,
+    )
+    ble_module.bluetooth.async_last_service_info.return_value = service_info
+    coordinator._update_device_from_service_info(service_info)
+    coordinator.device.should_retry_connection = False
+    ble_module.establish_connection = AsyncMock()
+    original_sleep = ble_module.asyncio.sleep
+    ble_module.asyncio.sleep = AsyncMock(side_effect=asyncio.CancelledError())
+
+    try:
+        asyncio.run(coordinator._shunt_notification_loop())
+    finally:
+        ble_module.asyncio.sleep = original_sleep
+
+    ble_module.establish_connection.assert_not_awaited()
 
 
 def test_sustained_shunt_listener_waits_for_started_scanner_and_fresh_advertisement():
@@ -1074,6 +1271,7 @@ def test_shunt_poll_keeps_last_good_data_when_library_read_fails():
         scan_interval=30,
         device_type="shunt300",
         shunt_connection_mode="intermittent",
+        max_failures=1,
     )
     cached_data = {"shunt_voltage": 13.2, "reading_verified": True}
     failed_read_data = {"shunt_voltage": 15.7, "reading_verified": False}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import MagicMock
 
+import pytest
+import voluptuous as vol
+
 
 def _load_config_flow_module() -> Any:
     """Load config_flow with minimal Home Assistant stubs."""
@@ -131,14 +134,19 @@ def _load_config_flow_module() -> Any:
             entry: Any,
             *,
             data_updates: dict[str, Any] | None = None,
+            options: dict[str, Any] | None = None,
         ) -> dict[str, Any]:
             """Apply data updates and abort like Home Assistant does."""
             entry.data = {**entry.data, **(data_updates or {})}
+            if options is not None:
+                entry.options = options
             self.last_data_updates = data_updates
+            self.last_options = options
             return {
                 "type": "abort",
                 "reason": "reconfigure_successful",
                 "data_updates": data_updates,
+                "options": options,
             }
 
     class OptionsFlow:
@@ -331,6 +339,7 @@ def _make_reconfigure_flow(
     const_module: Any,
     *,
     data: dict[str, Any],
+    options: dict[str, Any] | None = None,
     coordinator_model: str | None = None,
 ) -> tuple[Any, Any]:
     """Build a flow + entry pair prepared for reconfiguration."""
@@ -340,6 +349,7 @@ def _make_reconfigure_flow(
         entry_id="test-entry-id",
         title="BT-TH-A58A8FD4",
         data=data,
+        options=options or {},
     )
 
     flow = config_flow_module.RenogyConfigFlow()
@@ -388,6 +398,25 @@ def test_reconfigure_form_defaults_to_current_entry_values() -> None:
         == const_module.DeviceType.CONTROLLER.value
     )
     assert _schema_default(schema, "scan_interval") == 120
+
+
+def test_reconfigure_form_defaults_to_options_scan_interval() -> None:
+    """The form should show the active options-backed polling interval."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, _entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+            const_module.CONF_SCAN_INTERVAL: 60,
+        },
+        options={const_module.CONF_SCAN_INTERVAL: 45},
+    )
+
+    form_result = asyncio.run(flow.async_step_reconfigure())
+
+    assert _schema_default(form_result["data_schema"], "scan_interval") == 45
 
 
 def test_reconfigure_form_suggests_dcc_from_reported_model() -> None:
@@ -446,6 +475,42 @@ def test_reconfigure_updates_device_type_and_reloads() -> None:
         const_module.CONF_DEVICE_TYPE: const_module.DeviceType.DCC.value,
         "scan_interval": 60,
     }
+    assert entry.options == {"scan_interval": 60}
+
+
+def test_reconfigure_updates_scan_interval_already_saved_in_options() -> None:
+    """Reconfigure must not leave an older options value shadowing entry data."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            "address": "CC:45:A5:8A:8F:D4",
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+            const_module.CONF_SCAN_INTERVAL: 60,
+        },
+        options={
+            const_module.CONF_SCAN_INTERVAL: 45,
+            const_module.CONF_MAX_FAILURES: 5,
+        },
+    )
+
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.CONTROLLER.value,
+                const_module.CONF_SCAN_INTERVAL: 120,
+            }
+        )
+    )
+
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[const_module.CONF_SCAN_INTERVAL] == 120
+    assert entry.options == {
+        const_module.CONF_SCAN_INTERVAL: 120,
+        const_module.CONF_MAX_FAILURES: 5,
+    }
 
 
 def test_reconfigure_rejects_unsupported_device_type() -> None:
@@ -497,3 +562,117 @@ def test_reconfigure_form_handles_missing_coordinator() -> None:
         _schema_default(form_result["data_schema"], const_module.CONF_DEVICE_TYPE)
         == const_module.DeviceType.DCC.value
     )
+
+
+def _schema_keys(data_schema: vol.Schema) -> set[str]:
+    """Return the set of field keys declared by a voluptuous schema."""
+    return {marker.schema for marker in data_schema.schema}
+
+
+def _options_entry(const_module: Any, device_type: str, options: Any = None) -> Any:
+    """Build a stub config entry for options-flow tests."""
+    return types.SimpleNamespace(
+        data={const_module.CONF_DEVICE_TYPE: device_type},
+        options=options or {},
+    )
+
+
+def test_options_flow_shows_all_three_knobs() -> None:
+    """The options form exposes poll interval, failure grace, reconnect interval."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+
+    entry = _options_entry(const_module, const_module.DeviceType.CONTROLLER.value)
+    handler = config_flow_module.RenogyOptionsFlowHandler(entry)
+
+    form = asyncio.run(handler.async_step_init(None))
+
+    assert form["type"] == "form"
+    assert _schema_keys(form["data_schema"]) >= {
+        const_module.CONF_SCAN_INTERVAL,
+        const_module.CONF_MAX_FAILURES,
+        const_module.CONF_UNAVAILABLE_RETRY_INTERVAL,
+    }
+
+
+def test_options_flow_shunt_shows_knobs_and_connection_mode() -> None:
+    """The shunt options form keeps connection mode and gains the three knobs."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+
+    entry = _options_entry(const_module, const_module.DeviceType.SHUNT300.value)
+    handler = config_flow_module.RenogyOptionsFlowHandler(entry)
+
+    form = asyncio.run(handler.async_step_init(None))
+
+    assert _schema_keys(form["data_schema"]) >= {
+        const_module.CONF_SHUNT_CONNECTION_MODE,
+        const_module.CONF_SCAN_INTERVAL,
+        const_module.CONF_MAX_FAILURES,
+        const_module.CONF_UNAVAILABLE_RETRY_INTERVAL,
+    }
+
+
+def test_options_flow_accepts_and_stores_valid_input() -> None:
+    """Valid options are stored in the entry options."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+
+    entry = _options_entry(const_module, const_module.DeviceType.CONTROLLER.value)
+    handler = config_flow_module.RenogyOptionsFlowHandler(entry)
+
+    user_input = {
+        const_module.CONF_SCAN_INTERVAL: 30,
+        const_module.CONF_MAX_FAILURES: 5,
+        const_module.CONF_UNAVAILABLE_RETRY_INTERVAL: 2,
+    }
+    result = asyncio.run(handler.async_step_init(user_input))
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == user_input
+
+
+@pytest.mark.parametrize("filename", ["strings.json", "translations/en.json"])
+def test_runtime_options_have_user_facing_labels(filename: str) -> None:
+    """Every runtime option should have a canonical English label."""
+    integration_path = (
+        Path(__file__).resolve().parents[1] / "custom_components" / "renogy"
+    )
+    labels = json.loads((integration_path / filename).read_text())["options"]["step"][
+        "init"
+    ]["data"]
+
+    assert labels["scan_interval"] == "Polling interval (seconds)"
+    assert labels["max_failures"] == "Failed polls before unavailable"
+    assert labels["unavailable_retry_interval"] == (
+        "Reconnect interval while unavailable (minutes)"
+    )
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("CONF_SCAN_INTERVAL", 5),
+        ("CONF_MAX_FAILURES", 0),
+        ("CONF_UNAVAILABLE_RETRY_INTERVAL", 999),
+    ],
+)
+def test_options_flow_rejects_out_of_range(field: str, value: int) -> None:
+    """The options schema range-validates every knob."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+
+    entry = _options_entry(const_module, const_module.DeviceType.CONTROLLER.value)
+    handler = config_flow_module.RenogyOptionsFlowHandler(entry)
+    schema = asyncio.run(handler.async_step_init(None))["data_schema"]
+
+    key = getattr(const_module, field)
+    valid = {
+        const_module.CONF_SCAN_INTERVAL: 30,
+        const_module.CONF_MAX_FAILURES: 3,
+        const_module.CONF_UNAVAILABLE_RETRY_INTERVAL: 10,
+    }
+    valid[key] = value
+
+    with pytest.raises(vol.Invalid):
+        schema(valid)

--- a/tests/test_hub_setup.py
+++ b/tests/test_hub_setup.py
@@ -104,6 +104,11 @@ def test_communication_hub_option_enables_hub_coordinator() -> None:
     assert result is True
     assert hub_class.last_init is not None
     assert hub_class.last_init["communication_hub_enabled"] is True
+    assert hub_class.last_init["max_failures"] == module.DEFAULT_MAX_FAILURES
+    assert (
+        hub_class.last_init["unavailable_retry_interval"]
+        == module.DEFAULT_UNAVAILABLE_RETRY_INTERVAL
+    )
     assert base_class.last_init is None
     assert isinstance(
         hass.data[module.DOMAIN][entry.entry_id]["coordinator"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -188,6 +188,71 @@ def test_async_setup_entry_uses_configured_non_shunt_connection_mode() -> None:
     entry.add_update_listener.assert_called_once()
 
 
+def test_async_setup_entry_threads_grace_and_reconnect_options() -> None:
+    """Setup resolves the three knobs from options and passes them along."""
+    init_module, coordinator_class = _load_init_module()
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.async_create_task = lambda coro: asyncio.get_running_loop().create_task(coro)
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {
+        "address": "AA:BB:CC:DD:EE:FF",
+        init_module.CONF_DEVICE_TYPE: init_module.DeviceType.CONTROLLER.value,
+        init_module.CONF_SCAN_INTERVAL: 60,
+    }
+    entry.options = {
+        init_module.CONF_SCAN_INTERVAL: 45,
+        init_module.CONF_MAX_FAILURES: 5,
+        init_module.CONF_UNAVAILABLE_RETRY_INTERVAL: 2,
+    }
+    entry.add_update_listener = MagicMock(return_value=lambda: None)
+    entry.async_on_unload = MagicMock()
+
+    result = asyncio.run(init_module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert coordinator_class.last_init is not None
+    # Options override entry.data for the poll interval.
+    assert coordinator_class.last_init["scan_interval"] == 45
+    assert coordinator_class.last_init["max_failures"] == 5
+    assert coordinator_class.last_init["unavailable_retry_interval"] == 2
+
+
+def test_async_setup_entry_defaults_grace_and_reconnect_when_unset() -> None:
+    """Absent options fall back to entry.data then the documented defaults."""
+    init_module, coordinator_class = _load_init_module()
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.async_create_task = lambda coro: asyncio.get_running_loop().create_task(coro)
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {
+        "address": "AA:BB:CC:DD:EE:FF",
+        init_module.CONF_DEVICE_TYPE: init_module.DeviceType.CONTROLLER.value,
+        init_module.CONF_SCAN_INTERVAL: 60,
+    }
+    entry.options = {}
+    entry.add_update_listener = MagicMock(return_value=lambda: None)
+    entry.async_on_unload = MagicMock()
+
+    result = asyncio.run(init_module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert coordinator_class.last_init["scan_interval"] == 60
+    assert (
+        coordinator_class.last_init["max_failures"] == init_module.DEFAULT_MAX_FAILURES
+    )
+    assert (
+        coordinator_class.last_init["unavailable_retry_interval"]
+        == init_module.DEFAULT_UNAVAILABLE_RETRY_INTERVAL
+    )
+
+
 def test_reload_listener_reloads_entry() -> None:
     """Ensure option updates trigger a config-entry reload."""
     init_module, _ = _load_init_module()


### PR DESCRIPTION
**Benefit:** Lets users tune polling and BLE dropout tolerance straight from the options flow — poll interval, failure grace, and reconnect cooldown — without reconfiguring the device. Pairs with grace-governed availability to tame flaky links from the UI.

## What this adds

Three range-validated options in the options flow — poll interval, failure grace (consecutive missed polls tolerated before a device is marked unavailable), and reconnect cooldown. Each is resolved options → data → default and applied to the coordinator and device on setup and reload, so edits take effect without reconfiguring the device.

## Pre-merge checklist

- [x] renogy-ble#126 merged and `renogy-ble` v2.5.0 released to PyPI
- [x] rebased onto main (`renogy-ble==2.5.0`)
- [x] all gates pass locally: ruff format, ruff check, ty check, pytest
- [x] marked ready for review

## Tests

Test suite passes (94 tests), type-check clean against renogy-ble 2.5.0.
