### PR TITLE
fix: write DCC solar cutoff current in centiamps

### DIFF
--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -35,7 +35,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.4.0"
+    "renogy-ble==2.4.1"
   ],
   "version": "0.7.1"
 }

--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -284,7 +284,7 @@ DCC_OTHER_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         mode=NumberMode.BOX,
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.SOLAR_CUTOFF_CURRENT,
-        scale=1.0,
+        scale=100.0,  # 7.0A -> 700 centiamps
         value_fn=lambda data: data.get("solar_cutoff_current"),
     ),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2026.5.4",
-    "renogy-ble==2.4.0",
+    "renogy-ble==2.4.1",
 ]
 
 [dependency-groups]

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,195 @@
+"""Tests for Renogy BLE writable number entities."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _install_module_stubs() -> None:
+    """Install minimal Home Assistant module stubs to import the number module."""
+    homeassistant_module = cast(Any, types.ModuleType("homeassistant"))
+    sys.modules["homeassistant"] = homeassistant_module
+
+    components_module = cast(Any, types.ModuleType("homeassistant.components"))
+    sys.modules["homeassistant.components"] = components_module
+
+    number_module = cast(Any, types.ModuleType("homeassistant.components.number"))
+
+    class NumberEntity:
+        """Stub number entity base class for testing."""
+
+    @dataclass(frozen=True)
+    class NumberEntityDescription:
+        """Stub number entity description for testing."""
+
+        key: str | None = None
+        name: str | None = None
+        native_unit_of_measurement: str | None = None
+        device_class: str | None = None
+        native_min_value: float | None = None
+        native_max_value: float | None = None
+        native_step: float | None = None
+        mode: str | None = None
+        entity_category: str | None = None
+
+    class NumberDeviceClass:
+        """Stub number device classes."""
+
+        CURRENT = "current"
+        VOLTAGE = "voltage"
+
+    class NumberMode:
+        """Stub number input modes."""
+
+        BOX = "box"
+
+    number_module.NumberEntity = NumberEntity
+    number_module.NumberEntityDescription = NumberEntityDescription
+    number_module.NumberDeviceClass = NumberDeviceClass
+    number_module.NumberMode = NumberMode
+    sys.modules["homeassistant.components.number"] = number_module
+
+    config_entries_module = cast(Any, types.ModuleType("homeassistant.config_entries"))
+
+    class ConfigEntry:
+        """Stub config entry class for testing."""
+
+    config_entries_module.ConfigEntry = ConfigEntry
+    sys.modules["homeassistant.config_entries"] = config_entries_module
+
+    const_module = cast(Any, types.ModuleType("homeassistant.const"))
+    const_module.CONF_ADDRESS = "address"
+
+    class Platform(str, Enum):
+        """Stub platform enum values."""
+
+        SENSOR = "sensor"
+        NUMBER = "number"
+        SELECT = "select"
+        SWITCH = "switch"
+
+    class UnitOfElectricCurrent:
+        """Stub current units."""
+
+        AMPERE = "A"
+
+    class UnitOfElectricPotential:
+        """Stub voltage units."""
+
+        VOLT = "V"
+
+    class UnitOfTime:
+        """Stub time units."""
+
+        DAYS = "d"
+        MINUTES = "min"
+        SECONDS = "s"
+
+    const_module.Platform = Platform
+    const_module.UnitOfElectricCurrent = UnitOfElectricCurrent
+    const_module.UnitOfElectricPotential = UnitOfElectricPotential
+    const_module.UnitOfTime = UnitOfTime
+    sys.modules["homeassistant.const"] = const_module
+
+    core_module = cast(Any, types.ModuleType("homeassistant.core"))
+
+    class HomeAssistant:
+        """Stub Home Assistant class for testing."""
+
+    core_module.HomeAssistant = HomeAssistant
+    sys.modules["homeassistant.core"] = core_module
+
+    helpers_module = cast(Any, types.ModuleType("homeassistant.helpers"))
+    sys.modules["homeassistant.helpers"] = helpers_module
+
+    device_registry_module = cast(
+        Any, types.ModuleType("homeassistant.helpers.device_registry")
+    )
+
+    class DeviceInfo(dict):
+        """Stub device info that stores provided fields."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+    device_registry_module.DeviceInfo = DeviceInfo
+    device_registry_module.async_get = MagicMock()
+    sys.modules["homeassistant.helpers.device_registry"] = device_registry_module
+
+    entity_module = cast(Any, types.ModuleType("homeassistant.helpers.entity"))
+
+    class EntityCategory:
+        """Stub entity categories."""
+
+        CONFIG = "config"
+
+    entity_module.EntityCategory = EntityCategory
+    sys.modules["homeassistant.helpers.entity"] = entity_module
+
+    entity_platform_module = cast(
+        Any, types.ModuleType("homeassistant.helpers.entity_platform")
+    )
+
+    class AddEntitiesCallback:
+        """Stub add entities callback for testing."""
+
+    entity_platform_module.AddEntitiesCallback = AddEntitiesCallback
+    sys.modules["homeassistant.helpers.entity_platform"] = entity_platform_module
+
+    ble_module = cast(Any, types.ModuleType("custom_components.renogy.ble"))
+
+    class RenogyActiveBluetoothCoordinator:
+        """Stub coordinator class for testing."""
+
+    class RenogyBLEDevice:
+        """Stub BLE device class for testing."""
+
+    ble_module.RenogyActiveBluetoothCoordinator = RenogyActiveBluetoothCoordinator
+    ble_module.RenogyBLEDevice = RenogyBLEDevice
+    sys.modules["custom_components.renogy.ble"] = ble_module
+
+
+def _load_number_module() -> Any:
+    """Load the number module with stubs in place."""
+    _install_module_stubs()
+    sys.modules.pop("custom_components.renogy.number", None)
+    sys.modules.pop("custom_components.renogy", None)
+    return importlib.import_module("custom_components.renogy.number")
+
+
+def test_solar_cutoff_current_writes_centiamps() -> None:
+    """Ensure a solar cutoff value in amps is written as centiamps."""
+    number_module = _load_number_module()
+    description = next(
+        description
+        for description in number_module.DCC_OTHER_NUMBERS
+        if description.key == "solar_cutoff_current"
+    )
+
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+    coordinator.async_write_register = AsyncMock(return_value=True)
+
+    entity = number_module.RenogyNumberEntity(
+        coordinator=coordinator,
+        device=None,
+        description=description,
+        device_type=number_module.DeviceType.DCC.value,
+    )
+    entity.async_write_ha_state = MagicMock()
+
+    asyncio.run(entity.async_set_native_value(7.0))
+
+    coordinator.async_write_register.assert_awaited_once_with(
+        number_module.DCCRegister.SOLAR_CUTOFF_CURRENT,
+        700,
+    )
+    assert entity.native_value == 7.0
+    entity.async_write_ha_state.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1505,15 +1505,15 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.4.0"
+version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/dd/5588e9a8e8b7205108a95afbf3d5dd01060b6c888ad850f5ef84bf9803e8/renogy_ble-2.4.0.tar.gz", hash = "sha256:45a798202cc6ba1f9f6b69dc41d0c1c2ab5937431f01f3545a3ce0d4265294db", size = 67089, upload-time = "2026-07-23T02:39:25.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/65/aff4d68de98a9deb4f74d1026883a84beba57c1c066d594615f0ee018798/renogy_ble-2.4.1.tar.gz", hash = "sha256:3893e0d5df99e5e8ef9cc7d98004ea03b3d186c2ed13275fbd0a5cf84de952d5", size = 66157, upload-time = "2026-08-07T02:26:23.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/f7/4a96e817329403805e007750c3d7f757281cbb440dda13fcb253930fcbca/renogy_ble-2.4.0-py3-none-any.whl", hash = "sha256:b3bea5998492f1e530b3e7e589dd1c12b7bb895ffac284904847328a68a6756e", size = 29526, upload-time = "2026-07-23T02:39:25.018Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b1/107007a3bfd48fde74affbec00f25478b15f4f3cb226638c6d244c3b35b5/renogy_ble-2.4.1-py3-none-any.whl", hash = "sha256:619fe2c4e47a523ffb6d63184bed152ceb76e85be2387bd7bf1522104a2b7395", size = 30082, upload-time = "2026-08-07T02:26:22.861Z" },
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.5.4" },
-    { name = "renogy-ble", specifier = "==2.4.0" },
+    { name = "renogy-ble", specifier = "==2.4.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Problem

The DCC stores `solar_cutoff_current` (register `0xE038`) in centiamps, but the number entity writes the raw amp value with `scale=1.0`. Setting 7 A wrote `7` — i.e. **0.07 A**. Because `native_max_value` is `10`, the entity could never write more than **0.10 A**, so this control has never been usable.

Every other writable DCC parameter already pairs its entity scale with the reciprocal scale in `renogy-ble`'s register map:

| Parameter | register map | entity |
|---|---|---|
| `overvoltage_threshold` | `0.1` | `10.0` |
| `charging_limit_voltage` | `0.1` | `10.0` |
| `reverse_charging_voltage` | `0.1` | `10.0` |
| `solar_cutoff_current` | `1.0` | `1.0` ← both sides wrong |

`max_charging_current` (`0xE001`) is the same units and already converts to centiamps explicitly in `select.py` via `DCC_MAX_CURRENT_TO_DEVICE`.

## Depends on

https://github.com/IAmTheMitchell/renogy-ble/pull/127, which adds the matching `scale: 0.01` on the read side. **This PR should land after that releases**, along with a bump of the `renogy-ble` pin in `manifest.json` and `pyproject.toml` — happy to add that bump here once you cut the release, or to have it done in a follow-up, whichever you prefer.

Applying only this change leaves reads 100x too high; applying only the library change leaves writes 100x too low.

## Verification on real hardware

Tested against a live DCC50S on Home Assistant `2026.7.4` with both fixes applied:

- Set **5 A** from the Home Assistant number entity → the official Renogy app showed **5 A**.
- Set **3 A** in the app → Home Assistant read back **3.0**.
- Before the fix, the same entity recorded `700.0` for an app setting of 7 A.

## Tests

No new test here: the repo has no number-entity tests to extend, and the invariant worth pinning — that the two scales are reciprocal — cannot be asserted until the `renogy-ble` pin is bumped, so it would fail CI today. The wire-format contract is covered by the test in the library PR. Glad to add a number-entity test if you would like one.