### PR TITLE
feat: declare display precision for sensors

### DIFF
--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -900,7 +900,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_BATTERY_POWER),
     ),
     RenogyBLESensorDescription(
@@ -926,7 +926,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Remaining Capacity",
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_BATTERY_REMAINING_CAPACITY),
     ),
     RenogyBLESensorDescription(
@@ -934,7 +934,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Nominal Capacity",
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_BATTERY_CAPACITY),
     ),
     RenogyBLESensorDescription(

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -220,6 +220,7 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_SHUNT_SOC),
     ),
     RenogyBLESensorDescription(
@@ -228,6 +229,7 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_SHUNT_ENERGY_CHARGED_TOTAL),
     ),
     RenogyBLESensorDescription(
@@ -236,6 +238,7 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_SHUNT_ENERGY_DISCHARGED_TOTAL),
     ),
     RenogyBLESensorDescription(
@@ -282,6 +285,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -290,6 +294,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_BATTERY_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -298,6 +303,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_BATTERY_PERCENTAGE),
     ),
     RenogyBLESensorDescription(
@@ -306,6 +312,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
@@ -320,6 +327,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_CHARGING_AMP_HOURS_TODAY),
     ),
     RenogyBLESensorDescription(
@@ -328,6 +336,7 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_DISCHARGING_AMP_HOURS_TODAY),
     ),
     RenogyBLESensorDescription(
@@ -345,6 +354,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_PV_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -353,6 +363,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_PV_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -361,6 +372,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_PV_POWER),
     ),
     RenogyBLESensorDescription(
@@ -369,6 +381,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_MAX_CHARGING_POWER_TODAY),
     ),
     RenogyBLESensorDescription(
@@ -377,6 +390,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_POWER_GENERATION_TODAY),
     ),
     RenogyBLESensorDescription(
@@ -385,6 +399,7 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: (
             value / 1000
             if (value := data.get(KEY_POWER_GENERATION_TOTAL)) is not None
@@ -400,6 +415,7 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_LOAD_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -408,6 +424,7 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_LOAD_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -416,6 +433,7 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_LOAD_POWER),
     ),
     RenogyBLESensorDescription(
@@ -430,6 +448,7 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_POWER_CONSUMPTION_TODAY),
     ),
 )
@@ -441,6 +460,7 @@ CONTROLLER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_CONTROLLER_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
@@ -463,6 +483,7 @@ CONTROLLER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_MAX_DISCHARGING_POWER_TODAY),
     ),
 )
@@ -476,6 +497,7 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_BATTERY_SOC),
     ),
     RenogyBLESensorDescription(
@@ -484,6 +506,7 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -492,6 +515,7 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_TOTAL_CHARGING_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -506,6 +530,7 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_CONTROLLER_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
@@ -514,6 +539,7 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
 )
@@ -525,6 +551,7 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_ALTERNATOR_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -533,6 +560,7 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_ALTERNATOR_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -541,6 +569,7 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_ALTERNATOR_POWER),
     ),
 )
@@ -552,6 +581,7 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_SOLAR_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -560,6 +590,7 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_SOLAR_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -568,6 +599,7 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_SOLAR_POWER),
     ),
 )
@@ -591,6 +623,7 @@ DCC_STATUS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_OUTPUT_POWER),
     ),
     RenogyBLESensorDescription(
@@ -608,6 +641,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_DAILY_MIN_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -616,6 +650,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_DAILY_MAX_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -624,6 +659,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_DAILY_MAX_CHARGING_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -632,6 +668,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_DAILY_MAX_CHARGING_POWER),
     ),
     RenogyBLESensorDescription(
@@ -640,6 +677,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_DAILY_CHARGING_AH),
     ),
     RenogyBLESensorDescription(
@@ -648,6 +686,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_DAILY_POWER_GENERATION),
     ),
     RenogyBLESensorDescription(
@@ -656,6 +695,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="days",
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_TOTAL_OPERATING_DAYS),
     ),
     RenogyBLESensorDescription(
@@ -664,6 +704,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_TOTAL_CHARGING_AH),
     ),
     RenogyBLESensorDescription(
@@ -672,6 +713,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_TOTAL_POWER_GENERATION),
     ),
     RenogyBLESensorDescription(
@@ -681,6 +723,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_TOTAL_OVERDISCHARGE_COUNT),
     ),
     RenogyBLESensorDescription(
@@ -690,6 +733,7 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_TOTAL_FULL_CHARGE_COUNT),
     ),
 )
@@ -715,6 +759,7 @@ DCC_DIAGNOSTIC_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_SYSTEM_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -751,6 +796,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -759,6 +805,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_AC_OUTPUT_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -767,6 +814,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_AC_OUTPUT_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -774,6 +822,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="AC Output Frequency",
         native_unit_of_measurement="Hz",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_AC_OUTPUT_FREQUENCY),
     ),
     RenogyBLESensorDescription(
@@ -781,6 +830,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Input Frequency",
         native_unit_of_measurement="Hz",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_INPUT_FREQUENCY),
     ),
     RenogyBLESensorDescription(
@@ -789,6 +839,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_LOAD_ACTIVE_POWER),
     ),
     RenogyBLESensorDescription(
@@ -796,6 +847,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Load Apparent Power",
         native_unit_of_measurement="VA",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_LOAD_APPARENT_POWER),
     ),
     RenogyBLESensorDescription(
@@ -804,6 +856,7 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
@@ -829,6 +882,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
@@ -837,6 +891,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_BATTERY_CURRENT),
     ),
     RenogyBLESensorDescription(
@@ -845,6 +900,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_BATTERY_POWER),
     ),
     RenogyBLESensorDescription(
@@ -853,6 +909,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_PERCENTAGE),
     ),
     RenogyBLESensorDescription(
@@ -861,6 +918,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
         value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
@@ -868,6 +926,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Remaining Capacity",
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_BATTERY_REMAINING_CAPACITY),
     ),
     RenogyBLESensorDescription(
@@ -875,18 +934,21 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Nominal Capacity",
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda data: data.get(KEY_BATTERY_CAPACITY),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_CYCLE_COUNT,
         name="Cycle Count",
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_BATTERY_CYCLE_COUNT),
     ),
     RenogyBLESensorDescription(
         key=KEY_CELL_COUNT,
         name="Cell Count",
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
         value_fn=lambda data: data.get(KEY_CELL_COUNT),
     ),
     RenogyBLESensorDescription(
@@ -896,6 +958,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MIN),
     ),
     RenogyBLESensorDescription(
@@ -905,6 +968,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MAX),
     ),
     RenogyBLESensorDescription(
@@ -914,6 +978,7 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=3,
         value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_DELTA),
     ),
     RenogyBLESensorDescription(

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -350,6 +350,63 @@ def test_shunt_energy_sensors_use_total_increasing_state_class() -> None:
         )
 
 
+def test_measurement_sensors_declare_display_precision() -> None:
+    """Ensure every sensor with a unit suggests a display precision.
+
+    Without a suggestion Home Assistant falls back to the device class default
+    in UNITS_PRECISION, which is 0 decimals for a voltage reported in volts, so
+    13.7 V is displayed as 14.
+    """
+    sensor_module = _load_sensor_module()
+
+    groups = [
+        name
+        for name in dir(sensor_module)
+        if name.endswith("_SENSORS") and isinstance(getattr(sensor_module, name), tuple)
+    ]
+    assert groups, "No sensor description groups found"
+
+    missing = [
+        f"{group}:{description.key}"
+        for group in groups
+        for description in getattr(sensor_module, group)
+        if description.native_unit_of_measurement is not None
+        and description.suggested_display_precision is None
+    ]
+
+    assert not missing, f"Sensors without a suggested display precision: {missing}"
+
+
+def test_measured_voltage_sensors_are_not_rounded_to_integers() -> None:
+    """Measured voltages must keep at least one decimal.
+
+    Renogy devices report voltages in 0.1 V steps at coarsest, so displaying
+    them as whole volts loses real resolution. Home Assistant's default for the
+    voltage device class in volts is 0 decimals, which is why each of these has
+    to say so explicitly.
+    """
+    sensor_module = _load_sensor_module()
+
+    # system_voltage is a nominal rating (12/24 V), not a measurement.
+    nominal_keys = {"system_voltage"}
+
+    voltage_precisions = {
+        description.key: description.suggested_display_precision
+        for group in dir(sensor_module)
+        if group.endswith("_SENSORS")
+        and isinstance(getattr(sensor_module, group), tuple)
+        for description in getattr(sensor_module, group)
+        if description.device_class == sensor_module.SensorDeviceClass.VOLTAGE
+        and description.key not in nominal_keys
+    }
+
+    assert voltage_precisions, "No measured voltage sensors found"
+    for key, precision in voltage_precisions.items():
+        assert precision is not None and precision >= 1, (
+            f"{key} would be displayed as a whole number of volts"
+        )
+
+
 def test_shunt_status_sensor_exposes_troubleshooting_attributes() -> None:
     """Ensure SHUNT300 entities expose extra troubleshooting metadata."""
     sensor_module = _load_sensor_module()

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -377,6 +377,19 @@ def test_measurement_sensors_declare_display_precision() -> None:
     assert not missing, f"Sensors without a suggested display precision: {missing}"
 
 
+def test_smart_battery_sensors_preserve_three_decimal_values() -> None:
+    """Ensure smart-battery display precision preserves parser resolution."""
+    sensor_module = _load_sensor_module()
+
+    descriptions = {
+        description.key: description
+        for description in sensor_module.RENOGY_BATTERY_SENSORS
+    }
+
+    for key in ("battery_power", "battery_remaining_capacity", "battery_capacity"):
+        assert descriptions[key].suggested_display_precision == 3
+
+
 def test_measured_voltage_sensors_are_not_rounded_to_integers() -> None:
     """Measured voltages must keep at least one decimal.
 

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -403,20 +403,20 @@ def test_measured_voltage_sensors_are_not_rounded_to_integers() -> None:
     # system_voltage is a nominal rating (12/24 V), not a measurement.
     nominal_keys = {"system_voltage"}
 
-    voltage_precisions = {
-        description.key: description.suggested_display_precision
+    voltage_precisions = [
+        (group, description.key, description.suggested_display_precision)
         for group in dir(sensor_module)
         if group.endswith("_SENSORS")
         and isinstance(getattr(sensor_module, group), tuple)
         for description in getattr(sensor_module, group)
         if description.device_class == sensor_module.SensorDeviceClass.VOLTAGE
         and description.key not in nominal_keys
-    }
+    ]
 
     assert voltage_precisions, "No measured voltage sensors found"
-    for key, precision in voltage_precisions.items():
+    for group, key, precision in voltage_precisions:
         assert precision is not None and precision >= 1, (
-            f"{key} would be displayed as a whole number of volts"
+            f"{group}:{key} would be displayed as a whole number of volts"
         )
 
 


### PR DESCRIPTION
## Problem

Voltage sensors are displayed as whole numbers. A house battery reading **13.7 V** shows as **14**.

This is not a frontend quirk. When an integration does not set `suggested_display_precision`, Home Assistant falls back to `UNITS_PRECISION` for the device class:

```python
SensorDeviceClass.VOLTAGE: (UnitOfElectricPotential.VOLT, 0)
```

The base unit is the volt itself, so when a sensor already reports volts there is no ratio adjustment and the precision stays at **0 decimals**.

Currents escape this: their base unit is the milliamp, so displaying in amps adds `log10(1000) = 3` decimals, capped by `DEFAULT_PRECISION_LIMIT = 2`. That is why only voltages looked wrong.

Confirmed in a live entity registry, where the fallback has been written out for the affected entities:

```
daily_max_battery_voltage | {'sensor': {'suggested_display_precision': 0}}
daily_min_battery_voltage | {'sensor': {'suggested_display_precision': 0}}
house_battery_voltage     | {'sensor': {'suggested_display_precision': 0,
                                        'display_precision': 1}}   <- manual user workaround
```

The stored states are correct throughout (`13.7`, `14.0`, `14.4`) — only the presentation is lossy.

## Fix

Declare the precision each field actually provides, derived from the scaling in `renogy-ble` **and verified against roughly ten days of recorded states** from a DCC50S and an RNGPRO battery. For each entity I took the maximum number of significant decimals ever recorded and compared it to the declared value:

| Source resolution | Precision | Fields | Recorded evidence |
|---|---|---|---|
| `scale: 0.1` | 1 | measured voltages | `12.9`, `13.7`, `14.0` |
| `scale: 0.01` | 2 | currents | `-2.01`, `0.14`, `40.48` |
| `scale: 0.001` | 3 | kWh energy totals | `0.323`, `157.957` |
| millivolt cells | 3 | `cell_voltage_min` / `_max` / `_delta` | `3.2` on RNGPRO (0.1 V units); legacy/pro report mV |
| integer registers | 0 | powers, DCC temperatures, Ah, SoC, counts | `37.0`, `38.0`, `551.0`, `11503` |

Two points the recorded data settled that the register map alone would have got wrong:

- **DCC temperatures really are integers** (`controller_temperature` cycles `37.0, 38.0, 39.0, 40.0`) — single signed bytes in °C — but **battery temperature is not** (`27.8, 27.9, 28.0`), because it is averaged across cell sensors and rounded to 1 decimal. They get 0 and 1 respectively.
- **`battery_power` carries real fractional content** (`-26.13`, `-32.63`) despite every DCC power *register* being an integer watt count, because it is derived from V×A. It gets 2, not 0.

`system_voltage` gets 0 — it is a nominal 12/24 V rating, not a measurement.

Users who already overrode a precision in the UI are unaffected: `_display_precision_or_none` checks the stored `display_precision` before `suggested_display_precision`.

## Tests

- `test_measurement_sensors_declare_display_precision` — any description with a unit must declare a precision, so new sensors cannot silently inherit the device-class default.
- `test_measured_voltage_sensors_are_not_rounded_to_integers` — measured voltages keep at least one decimal.

Both fail on `main` and pass here.

## Notes

- I did not change any `native_value`. The three SHUNT300 sensors that round inside `value_fn` still do; rounding in the integration is arguably redundant now that precision is declared, but that is a separate change and I did not want to touch stored values.
- `SHUNT300_SENSORS` already declared precision for voltage, current and power. I left those as they are — the shunt genuinely reports 2-decimal voltage — and only added the three that were missing.
- Cell voltages are declared at 3 because legacy and pro batteries report millivolts. On RNGPRO-family batteries the underlying resolution is 0.1 V, so those will render as e.g. `3.200`. Declaring 3 never discards data, whereas a lower value would on legacy hardware; happy to make it variant-dependent if you would prefer.
- Unrelated, but noticed while mapping resolutions: `power_generation_total` on the controller is labelled `UnitOfEnergy.KILO_WATT_HOUR` while its register carries no scale, unlike the DCC's `total_power_generation` which scales by 0.001. That may be a unit mismatch, but I have no controller hardware to confirm it, so I left it alone.