### PR TITLE
refactor: simplify entity value lookups

### DIFF
--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Optional
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -39,7 +39,6 @@ class RenogyNumberEntityDescription(NumberEntityDescription):
     """Describes a Renogy number entity."""
 
     register: int = 0
-    value_fn: Optional[Callable[[dict[str, Any]], Any]] = None
     # Scale factor: device value = HA value * scale
     scale: float = 1.0
 
@@ -58,7 +57,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.OVERVOLTAGE_THRESHOLD,
         scale=10.0,  # 14.0V -> 140
-        value_fn=lambda data: data.get("overvoltage_threshold"),
     ),
     RenogyNumberEntityDescription(
         key="charging_limit_voltage",
@@ -72,7 +70,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.CHARGING_LIMIT_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("charging_limit_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="equalization_voltage",
@@ -86,7 +83,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.EQUALIZATION_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("equalization_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="boost_voltage",
@@ -100,7 +96,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.BOOST_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("boost_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="float_voltage",
@@ -114,7 +109,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.FLOAT_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("float_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="boost_return_voltage",
@@ -128,7 +122,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.BOOST_RETURN_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("boost_return_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="overdischarge_return_voltage",
@@ -142,7 +135,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.OVERDISCHARGE_RETURN_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("overdischarge_return_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="undervoltage_warning",
@@ -156,7 +148,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.UNDERVOLTAGE_WARNING,
         scale=10.0,
-        value_fn=lambda data: data.get("undervoltage_warning"),
     ),
     RenogyNumberEntityDescription(
         key="overdischarge_voltage",
@@ -170,7 +161,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.OVERDISCHARGE_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("overdischarge_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="discharge_limit_voltage",
@@ -184,7 +174,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.DISCHARGE_LIMIT_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("discharge_limit_voltage"),
     ),
     RenogyNumberEntityDescription(
         key="reverse_charging_voltage",
@@ -198,7 +187,6 @@ DCC_VOLTAGE_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.REVERSE_CHARGING_VOLTAGE,
         scale=10.0,
-        value_fn=lambda data: data.get("reverse_charging_voltage"),
     ),
 )
 
@@ -215,7 +203,6 @@ DCC_TIME_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.OVERDISCHARGE_DELAY,
         scale=1.0,
-        value_fn=lambda data: data.get("overdischarge_delay"),
     ),
     RenogyNumberEntityDescription(
         key="equalization_time",
@@ -228,7 +215,6 @@ DCC_TIME_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.EQUALIZATION_TIME,
         scale=1.0,
-        value_fn=lambda data: data.get("equalization_time"),
     ),
     RenogyNumberEntityDescription(
         key="boost_time",
@@ -241,7 +227,6 @@ DCC_TIME_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.BOOST_TIME,
         scale=1.0,
-        value_fn=lambda data: data.get("boost_time"),
     ),
     RenogyNumberEntityDescription(
         key="equalization_interval",
@@ -254,7 +239,6 @@ DCC_TIME_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.EQUALIZATION_INTERVAL,
         scale=1.0,
-        value_fn=lambda data: data.get("equalization_interval"),
     ),
 )
 
@@ -271,7 +255,6 @@ DCC_OTHER_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.TEMPERATURE_COMPENSATION,
         scale=1.0,
-        value_fn=lambda data: data.get("temperature_compensation"),
     ),
     RenogyNumberEntityDescription(
         key="solar_cutoff_current",
@@ -285,7 +268,6 @@ DCC_OTHER_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         register=DCCRegister.SOLAR_CUTOFF_CURRENT,
         scale=100.0,  # 7.0A -> 700 centiamps
-        value_fn=lambda data: data.get("solar_cutoff_current"),
     ),
 )
 
@@ -351,7 +333,6 @@ class RenogyNumberEntity(NumberEntity):
         self.coordinator = coordinator
         self._device = device
         self.entity_description = description
-        self._device_type = device_type
         self._attr_native_value = None
 
         # Device-dependent properties
@@ -390,10 +371,10 @@ class RenogyNumberEntity(NumberEntity):
         elif self.coordinator.data:
             data = self.coordinator.data
 
-        if not data or not self.entity_description.value_fn:
+        if not data:
             return None
 
-        value = self.entity_description.value_fn(data)
+        value = data.get(self.entity_description.key)
         if value is not None:
             self._attr_native_value = float(value)
         return self._attr_native_value

--- a/custom_components/renogy/select.py
+++ b/custom_components/renogy/select.py
@@ -26,15 +26,6 @@ from .const import (
     DeviceType,
 )
 
-# Battery type options for display
-BATTERY_TYPE_OPTIONS = [
-    "custom",
-    "open",
-    "sealed",
-    "gel",
-    "lithium",
-]
-
 # Human-readable names for display
 BATTERY_TYPE_DISPLAY_NAMES = {
     "custom": "Custom",
@@ -134,7 +125,6 @@ class RenogyBatteryTypeSelect(SelectEntity):
         self.coordinator = coordinator
         self._device = device
         self.entity_description = description
-        self._device_type = device_type
         self._attr_options = list(BATTERY_TYPE_DISPLAY_NAMES.values())
         self._attr_current_option = None
 
@@ -273,7 +263,6 @@ class RenogyMaxCurrentSelect(SelectEntity):
         self.coordinator = coordinator
         self._device = device
         self.entity_description = description
-        self._device_type = device_type
         self._attr_options = MAX_CURRENT_OPTIONS
         self._attr_current_option = None
 

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -37,8 +37,6 @@ from .const import (
     DEFAULT_DEVICE_TYPE,
     DOMAIN,
     LOGGER,
-    RENOGY_BT_PREFIX,
-    RENOGY_INVERTER_PREFIX,
     DeviceType,
 )
 
@@ -221,7 +219,6 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_SHUNT_SOC),
     ),
     RenogyBLESensorDescription(
         key=KEY_SHUNT_ENERGY_CHARGED_TOTAL,
@@ -230,7 +227,6 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_SHUNT_ENERGY_CHARGED_TOTAL),
     ),
     RenogyBLESensorDescription(
         key=KEY_SHUNT_ENERGY_DISCHARGED_TOTAL,
@@ -239,7 +235,6 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_SHUNT_ENERGY_DISCHARGED_TOTAL),
     ),
     RenogyBLESensorDescription(
         key=KEY_SHUNT_STATUS,
@@ -257,25 +252,8 @@ SHUNT300_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
     ),
 )
 
-# DCC Parameter keys (readable settings)
+# DCC parameter keys exposed as sensors.
 KEY_SYSTEM_VOLTAGE = "system_voltage"
-KEY_OVERVOLTAGE_THRESHOLD = "overvoltage_threshold"
-KEY_CHARGING_LIMIT_VOLTAGE = "charging_limit_voltage"
-KEY_EQUALIZATION_VOLTAGE = "equalization_voltage"
-KEY_BOOST_VOLTAGE = "boost_voltage"
-KEY_FLOAT_VOLTAGE = "float_voltage"
-KEY_BOOST_RETURN_VOLTAGE = "boost_return_voltage"
-KEY_OVERDISCHARGE_RETURN_VOLTAGE = "overdischarge_return_voltage"
-KEY_UNDERVOLTAGE_WARNING = "undervoltage_warning"
-KEY_OVERDISCHARGE_VOLTAGE = "overdischarge_voltage"
-KEY_DISCHARGE_LIMIT_VOLTAGE = "discharge_limit_voltage"
-KEY_OVERDISCHARGE_DELAY = "overdischarge_delay"
-KEY_EQUALIZATION_TIME = "equalization_time"
-KEY_BOOST_TIME = "boost_time"
-KEY_EQUALIZATION_INTERVAL = "equalization_interval"
-KEY_TEMPERATURE_COMPENSATION = "temperature_compensation"
-KEY_REVERSE_CHARGING_VOLTAGE = "reverse_charging_voltage"
-KEY_SOLAR_CUTOFF_CURRENT = "solar_cutoff_current"
 
 
 BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
@@ -286,7 +264,6 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_CURRENT,
@@ -295,7 +272,6 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_BATTERY_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_PERCENTAGE,
@@ -304,7 +280,6 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_BATTERY_PERCENTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_TEMPERATURE,
@@ -313,13 +288,11 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_TYPE,
         name="Battery Type",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_BATTERY_TYPE),
     ),
     RenogyBLESensorDescription(
         key=KEY_CHARGING_AMP_HOURS_TODAY,
@@ -328,7 +301,6 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_CHARGING_AMP_HOURS_TODAY),
     ),
     RenogyBLESensorDescription(
         key=KEY_DISCHARGING_AMP_HOURS_TODAY,
@@ -337,13 +309,11 @@ BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_DISCHARGING_AMP_HOURS_TODAY),
     ),
     RenogyBLESensorDescription(
         key=KEY_CHARGING_STATUS,
         name="Charging Status",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_CHARGING_STATUS),
     ),
 )
 
@@ -355,7 +325,6 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_PV_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_PV_CURRENT,
@@ -364,7 +333,6 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_PV_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_PV_POWER,
@@ -373,7 +341,6 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_PV_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_MAX_CHARGING_POWER_TODAY,
@@ -382,7 +349,6 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_MAX_CHARGING_POWER_TODAY),
     ),
     RenogyBLESensorDescription(
         key=KEY_POWER_GENERATION_TODAY,
@@ -391,7 +357,6 @@ PV_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_POWER_GENERATION_TODAY),
     ),
     RenogyBLESensorDescription(
         key=KEY_POWER_GENERATION_TOTAL,
@@ -416,7 +381,6 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_LOAD_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_LOAD_CURRENT,
@@ -425,7 +389,6 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_LOAD_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_LOAD_POWER,
@@ -434,13 +397,11 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_LOAD_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_LOAD_STATUS,
         name="Load Status",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_LOAD_STATUS),
     ),
     RenogyBLESensorDescription(
         key=KEY_POWER_CONSUMPTION_TODAY,
@@ -449,7 +410,6 @@ LOAD_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_POWER_CONSUMPTION_TODAY),
     ),
 )
 
@@ -461,21 +421,18 @@ CONTROLLER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_CONTROLLER_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
         key=KEY_DEVICE_ID,
         name="Device ID",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_DEVICE_ID),
     ),
     RenogyBLESensorDescription(
         key=KEY_MODEL,
         name="Model",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_MODEL),
     ),
     RenogyBLESensorDescription(
         key=KEY_MAX_DISCHARGING_POWER_TODAY,
@@ -484,7 +441,6 @@ CONTROLLER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_MAX_DISCHARGING_POWER_TODAY),
     ),
 )
 
@@ -498,7 +454,6 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_BATTERY_SOC),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_VOLTAGE,
@@ -507,7 +462,6 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_CHARGING_CURRENT,
@@ -516,13 +470,11 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_TOTAL_CHARGING_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_TYPE,
         name="Battery Type",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_BATTERY_TYPE),
     ),
     RenogyBLESensorDescription(
         key=KEY_CONTROLLER_TEMPERATURE,
@@ -531,7 +483,6 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_CONTROLLER_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_TEMPERATURE,
@@ -540,7 +491,6 @@ DCC_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
 )
 
@@ -552,7 +502,6 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_ALTERNATOR_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_ALTERNATOR_CURRENT,
@@ -561,7 +510,6 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_ALTERNATOR_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_ALTERNATOR_POWER,
@@ -570,7 +518,6 @@ DCC_ALTERNATOR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_ALTERNATOR_POWER),
     ),
 )
 
@@ -582,7 +529,6 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_SOLAR_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_SOLAR_CURRENT,
@@ -591,7 +537,6 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_SOLAR_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_SOLAR_POWER,
@@ -600,7 +545,6 @@ DCC_SOLAR_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_SOLAR_POWER),
     ),
 )
 
@@ -609,13 +553,11 @@ DCC_STATUS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         key=KEY_DCC_CHARGING_STATUS,
         name="Charging Status",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_DCC_CHARGING_STATUS),
     ),
     RenogyBLESensorDescription(
         key=KEY_CHARGING_MODE,
         name="Charging Mode",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_CHARGING_MODE),
     ),
     RenogyBLESensorDescription(
         key=KEY_OUTPUT_POWER,
@@ -624,13 +566,11 @@ DCC_STATUS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_OUTPUT_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_IGNITION_STATUS,
         name="Ignition Status",
         device_class=None,
-        value_fn=lambda data: data.get(KEY_IGNITION_STATUS),
     ),
 )
 
@@ -642,7 +582,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_DAILY_MIN_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_DAILY_MAX_BATTERY_VOLTAGE,
@@ -651,7 +590,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_DAILY_MAX_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_DAILY_MAX_CHARGING_CURRENT,
@@ -660,7 +598,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_DAILY_MAX_CHARGING_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_DAILY_MAX_CHARGING_POWER,
@@ -669,7 +606,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_DAILY_MAX_CHARGING_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_DAILY_CHARGING_AH,
@@ -678,7 +614,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_DAILY_CHARGING_AH),
     ),
     RenogyBLESensorDescription(
         key=KEY_DAILY_POWER_GENERATION,
@@ -687,7 +622,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_DAILY_POWER_GENERATION),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_OPERATING_DAYS,
@@ -696,7 +630,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_TOTAL_OPERATING_DAYS),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_CHARGING_AH,
@@ -705,7 +638,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=None,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_TOTAL_CHARGING_AH),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_POWER_GENERATION,
@@ -714,7 +646,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_TOTAL_POWER_GENERATION),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_OVERDISCHARGE_COUNT,
@@ -724,7 +655,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_TOTAL_OVERDISCHARGE_COUNT),
     ),
     RenogyBLESensorDescription(
         key=KEY_TOTAL_FULL_CHARGE_COUNT,
@@ -734,7 +664,6 @@ DCC_STATISTICS_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_TOTAL_FULL_CHARGE_COUNT),
     ),
 )
 
@@ -744,14 +673,12 @@ DCC_DIAGNOSTIC_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         name="Device ID",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_DEVICE_ID),
     ),
     RenogyBLESensorDescription(
         key=KEY_MODEL,
         name="Model",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_MODEL),
     ),
     RenogyBLESensorDescription(
         key=KEY_SYSTEM_VOLTAGE,
@@ -760,32 +687,19 @@ DCC_DIAGNOSTIC_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_SYSTEM_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_FAULT_HIGH,
         name="Fault Code High",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_FAULT_HIGH),
     ),
     RenogyBLESensorDescription(
         key=KEY_FAULT_LOW,
         name="Fault Code Low",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_FAULT_LOW),
     ),
-)
-
-# All DCC sensors combined
-DCC_ALL_SENSORS = (
-    DCC_BATTERY_SENSORS
-    + DCC_ALTERNATOR_SENSORS
-    + DCC_SOLAR_SENSORS
-    + DCC_STATUS_SENSORS
-    + DCC_STATISTICS_SENSORS
-    + DCC_DIAGNOSTIC_SENSORS
 )
 
 # Inverter sensors
@@ -797,7 +711,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_AC_OUTPUT_VOLTAGE,
@@ -806,7 +719,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_AC_OUTPUT_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_AC_OUTPUT_CURRENT,
@@ -815,7 +727,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_AC_OUTPUT_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_AC_OUTPUT_FREQUENCY,
@@ -823,7 +734,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Hz",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_AC_OUTPUT_FREQUENCY),
     ),
     RenogyBLESensorDescription(
         key=KEY_INPUT_FREQUENCY,
@@ -831,7 +741,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Hz",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_INPUT_FREQUENCY),
     ),
     RenogyBLESensorDescription(
         key=KEY_LOAD_ACTIVE_POWER,
@@ -840,7 +749,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_LOAD_ACTIVE_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_LOAD_APPARENT_POWER,
@@ -848,7 +756,6 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="VA",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_LOAD_APPARENT_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_TEMPERATURE,
@@ -857,21 +764,18 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
         key=KEY_DEVICE_ID,
         name="Device ID",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_DEVICE_ID),
     ),
     RenogyBLESensorDescription(
         key=KEY_MODEL,
         name="Model",
         device_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_MODEL),
     ),
 )
 
@@ -883,7 +787,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_VOLTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_CURRENT,
@@ -892,7 +795,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: data.get(KEY_BATTERY_CURRENT),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_POWER,
@@ -901,7 +803,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_BATTERY_POWER),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_PERCENTAGE,
@@ -910,7 +811,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_PERCENTAGE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_TEMPERATURE,
@@ -919,7 +819,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda data: data.get(KEY_BATTERY_TEMPERATURE),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_REMAINING_CAPACITY,
@@ -927,7 +826,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_BATTERY_REMAINING_CAPACITY),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_CAPACITY,
@@ -935,21 +833,18 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         native_unit_of_measurement="Ah",
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_BATTERY_CAPACITY),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_CYCLE_COUNT,
         name="Cycle Count",
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_BATTERY_CYCLE_COUNT),
     ),
     RenogyBLESensorDescription(
         key=KEY_CELL_COUNT,
         name="Cell Count",
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
-        value_fn=lambda data: data.get(KEY_CELL_COUNT),
     ),
     RenogyBLESensorDescription(
         key=KEY_CELL_VOLTAGE_MIN,
@@ -959,7 +854,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MIN),
     ),
     RenogyBLESensorDescription(
         key=KEY_CELL_VOLTAGE_MAX,
@@ -969,7 +863,6 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_MAX),
     ),
     RenogyBLESensorDescription(
         key=KEY_CELL_VOLTAGE_DELTA,
@@ -979,30 +872,23 @@ RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=3,
-        value_fn=lambda data: data.get(KEY_CELL_VOLTAGE_DELTA),
     ),
     RenogyBLESensorDescription(
         key=KEY_BATTERY_PROBLEM_CODE,
         name="Problem Code",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_BATTERY_PROBLEM_CODE),
     ),
     RenogyBLESensorDescription(
         key=KEY_MODEL,
         name="Model",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_MODEL),
     ),
     RenogyBLESensorDescription(
         key=KEY_SW_VERSION,
         name="Software Version",
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.get(KEY_SW_VERSION),
     ),
 )
-
-# All sensors combined (for controller type)
-ALL_SENSORS = BATTERY_SENSORS + PV_SENSORS + LOAD_SENSORS + CONTROLLER_SENSORS
 
 # Sensor mapping by device type
 SENSORS_BY_DEVICE_TYPE = {
@@ -1047,22 +933,18 @@ async def async_setup_entry(
     device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
     LOGGER.debug("Setting up sensors for device type: %s", device_type)
 
-    # Now create entities with the best name we have
-    if coordinator.device and (
-        coordinator.device.name.startswith(RENOGY_BT_PREFIX)
-        or coordinator.device.name.startswith(RENOGY_INVERTER_PREFIX)
-        or not coordinator.device.name.startswith("Unknown")
-    ):
-        LOGGER.info("Creating entities with device name: %s", coordinator.device.name)
-        device_entities = create_device_entities(
-            coordinator, coordinator.device, device_type
-        )
+    # Create entities with the best name currently available.
+    device = coordinator.device
+    if device and not device.name.startswith("Unknown"):
+        LOGGER.info("Creating entities with device name: %s", device.name)
     else:
         LOGGER.debug(
             "Creating sensor entities without waiting for a resolved device name"
         )
         LOGGER.info("Creating entities with coordinator only (generic name)")
-        device_entities = create_coordinator_entities(coordinator, device_type)
+        device = None
+
+    device_entities = create_entities_helper(coordinator, device, device_type)
 
     # Add all entities to Home Assistant
     if device_entities:
@@ -1094,27 +976,6 @@ def create_entities_helper(
             )
             entities.append(sensor)
 
-    return entities
-
-
-def create_coordinator_entities(
-    coordinator: RenogyActiveBluetoothCoordinator,
-    device_type: str = DEFAULT_DEVICE_TYPE,
-) -> List[RenogyBLESensor]:
-    """Create sensor entities with just the coordinator (no device yet)."""
-    entities = create_entities_helper(coordinator, None, device_type)
-    LOGGER.info("Created %s entities with coordinator only", len(entities))
-    return entities
-
-
-def create_device_entities(
-    coordinator: RenogyActiveBluetoothCoordinator,
-    device: RenogyBLEDevice,
-    device_type: str = DEFAULT_DEVICE_TYPE,
-) -> List[RenogyBLESensor]:
-    """Create sensor entities for a device."""
-    entities = create_entities_helper(coordinator, device, device_type)
-    LOGGER.info("Created %s entities for device %s", len(entities), device.name)
     return entities
 
 
@@ -1296,42 +1157,41 @@ class RenogyBLESensor(PassiveBluetoothCoordinatorEntity, RestoreEntity, SensorEn
             return None
 
         try:
-            if self.entity_description.value_fn:
-                value = self.entity_description.value_fn(data)
-                if (
-                    value is not None
-                    and self.entity_description.key in ENERGY_COUNTER_KEYS
-                ):
-                    value = self._apply_energy_reset_handling(value)
-                # Basic type validation based on device_class
-                if value is not None:
-                    if self.device_class in [
-                        SensorDeviceClass.VOLTAGE,
-                        SensorDeviceClass.CURRENT,
-                        SensorDeviceClass.TEMPERATURE,
-                        SensorDeviceClass.POWER,
-                    ]:
-                        try:
-                            value = float(value)
-                            # Basic range validation
-                            if value < -1000 or value > 10000:
-                                LOGGER.warning(
-                                    "Value %s out of reasonable range for %s",
-                                    value,
-                                    self.name,
-                                )
-                                return None
-                        except ValueError, TypeError:
-                            LOGGER.warning(
-                                "Invalid numeric value for %s: %s",
-                                self.name,
-                                value,
-                            )
-                            return None
+            value = (
+                self.entity_description.value_fn(data)
+                if self.entity_description.value_fn
+                else data.get(self.entity_description.key)
+            )
+            if value is not None and self.entity_description.key in ENERGY_COUNTER_KEYS:
+                value = self._apply_energy_reset_handling(value)
+            # Basic type validation based on device_class
+            if value is not None and self.device_class in [
+                SensorDeviceClass.VOLTAGE,
+                SensorDeviceClass.CURRENT,
+                SensorDeviceClass.TEMPERATURE,
+                SensorDeviceClass.POWER,
+            ]:
+                try:
+                    value = float(value)
+                    # Basic range validation
+                    if value < -1000 or value > 10000:
+                        LOGGER.warning(
+                            "Value %s out of reasonable range for %s",
+                            value,
+                            self.name,
+                        )
+                        return None
+                except ValueError, TypeError:
+                    LOGGER.warning(
+                        "Invalid numeric value for %s: %s",
+                        self.name,
+                        value,
+                    )
+                    return None
 
-                # Cache the value
-                self._attr_native_value = value
-                return value
+            # Cache the value
+            self._attr_native_value = value
+            return value
         except Exception as e:
             LOGGER.warning("Error getting native value for %s: %s", self.name, e)
         return None

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -164,6 +164,30 @@ def _load_number_module() -> Any:
     return importlib.import_module("custom_components.renogy.number")
 
 
+def test_number_reads_value_directly_from_description_key() -> None:
+    """Number descriptions should use their key for the current value."""
+    number_module = _load_number_module()
+    description = next(
+        description
+        for description in number_module.DCC_OTHER_NUMBERS
+        if description.key == "solar_cutoff_current"
+    )
+
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+    coordinator.device = None
+    coordinator.data = {"solar_cutoff_current": 7.5}
+
+    entity = number_module.RenogyNumberEntity(
+        coordinator=coordinator,
+        device=None,
+        description=description,
+        device_type=number_module.DeviceType.DCC.value,
+    )
+
+    assert entity.native_value == 7.5
+
+
 def test_solar_cutoff_current_writes_centiamps() -> None:
     """Ensure a solar cutoff value in amps is written as centiamps."""
     number_module = _load_number_module()

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -255,6 +255,22 @@ def _load_sensor_module() -> Any:
     return importlib.import_module("custom_components.renogy.sensor")
 
 
+def _read_sensor_value(
+    sensor_module: Any, description: Any, data: dict[str, Any]
+) -> Any:
+    """Return a sensor value through the entity's production lookup path."""
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+    coordinator.device = None
+    coordinator.data = data
+    entity = sensor_module.RenogyBLESensor(
+        coordinator=coordinator,
+        device=None,
+        description=description,
+    )
+    return entity.native_value
+
+
 def test_sensor_setup_does_not_wait_for_named_shunt() -> None:
     """Ensure setup skips refresh/wait loop when shunt name is already available."""
     sensor_module = _load_sensor_module()
@@ -279,15 +295,17 @@ def test_sensor_setup_does_not_wait_for_named_shunt() -> None:
 
     async_add_entities = MagicMock()
 
-    with patch.object(sensor_module, "create_device_entities", return_value=[]):
-        with patch.object(
-            sensor_module, "create_coordinator_entities", return_value=[]
-        ):
-            asyncio.run(
-                sensor_module.async_setup_entry(hass, config_entry, async_add_entities)
-            )
+    with patch.object(
+        sensor_module, "create_entities_helper", return_value=[]
+    ) as create:
+        asyncio.run(
+            sensor_module.async_setup_entry(hass, config_entry, async_add_entities)
+        )
 
     coordinator.async_request_refresh.assert_not_awaited()
+    create.assert_called_once_with(
+        coordinator, device, sensor_module.DeviceType.SHUNT300.value
+    )
     async_add_entities.assert_not_called()
 
 
@@ -311,19 +329,18 @@ def test_sensor_setup_does_not_wait_for_unknown_device_name() -> None:
 
     async_add_entities = MagicMock()
 
-    with patch.object(sensor_module, "create_device_entities", return_value=[]):
-        with patch.object(
-            sensor_module,
-            "create_coordinator_entities",
-            return_value=["entity"],
-        ) as create_coordinator_entities:
-            asyncio.run(
-                sensor_module.async_setup_entry(hass, config_entry, async_add_entities)
-            )
+    with patch.object(
+        sensor_module,
+        "create_entities_helper",
+        return_value=["entity"],
+    ) as create:
+        asyncio.run(
+            sensor_module.async_setup_entry(hass, config_entry, async_add_entities)
+        )
 
     coordinator.async_request_refresh.assert_not_awaited()
-    create_coordinator_entities.assert_called_once_with(
-        coordinator, sensor_module.DeviceType.CONTROLLER.value
+    create.assert_called_once_with(
+        coordinator, None, sensor_module.DeviceType.CONTROLLER.value
     )
     async_add_entities.assert_called_once_with(["entity"])
 
@@ -665,16 +682,18 @@ def test_inverter_sensor_mapping_uses_library_field_names() -> None:
         sensor_module.KEY_MODEL: "RIV1220PU-126",
     }
 
-    assert descriptions[sensor_module.KEY_BATTERY_VOLTAGE].value_fn(sample_data) == 40.0
-    assert (
-        descriptions[sensor_module.KEY_AC_OUTPUT_VOLTAGE].value_fn(sample_data) == 230.0
-    )
-    assert (
-        descriptions[sensor_module.KEY_LOAD_ACTIVE_POWER].value_fn(sample_data) == 500
-    )
-    assert (
-        descriptions[sensor_module.KEY_MODEL].value_fn(sample_data) == "RIV1220PU-126"
-    )
+    expected_values = {
+        sensor_module.KEY_BATTERY_VOLTAGE: 40.0,
+        sensor_module.KEY_AC_OUTPUT_VOLTAGE: 230.0,
+        sensor_module.KEY_LOAD_ACTIVE_POWER: 500,
+        sensor_module.KEY_MODEL: "RIV1220PU-126",
+    }
+    for key, expected in expected_values.items():
+        assert descriptions[key].value_fn is None
+        assert (
+            _read_sensor_value(sensor_module, descriptions[key], sample_data)
+            == expected
+        )
 
 
 def test_battery_sensor_mapping_uses_library_field_names() -> None:
@@ -703,11 +722,17 @@ def test_battery_sensor_mapping_uses_library_field_names() -> None:
         sensor_module.KEY_SW_VERSION: "2.10",
     }
 
-    assert descriptions[sensor_module.KEY_BATTERY_VOLTAGE].value_fn(sample_data) == 51.2
-    assert descriptions[sensor_module.KEY_BATTERY_POWER].value_fn(sample_data) == 631.8
-    assert descriptions[sensor_module.KEY_BATTERY_CAPACITY].value_fn(sample_data) == 100
-    assert descriptions[sensor_module.KEY_CELL_COUNT].value_fn(sample_data) == 4
-    assert (
-        descriptions[sensor_module.KEY_CELL_VOLTAGE_DELTA].value_fn(sample_data) == 0.3
-    )
-    assert descriptions[sensor_module.KEY_SW_VERSION].value_fn(sample_data) == "2.10"
+    expected_values = {
+        sensor_module.KEY_BATTERY_VOLTAGE: 51.2,
+        sensor_module.KEY_BATTERY_POWER: 631.8,
+        sensor_module.KEY_BATTERY_CAPACITY: 100,
+        sensor_module.KEY_CELL_COUNT: 4,
+        sensor_module.KEY_CELL_VOLTAGE_DELTA: 0.3,
+        sensor_module.KEY_SW_VERSION: "2.10",
+    }
+    for key, expected in expected_values.items():
+        assert descriptions[key].value_fn is None
+        assert (
+            _read_sensor_value(sensor_module, descriptions[key], sample_data)
+            == expected
+        )


### PR DESCRIPTION
## Summary

- make ordinary sensors read directly from `data[description.key]`
- make DCC number entities use the same direct-key path
- retain callbacks only for the five sensors that perform real transformations
- remove 99 redundant one-off lookup lambdas
- remove unused DCC sensor constants, aggregate tuples, battery option data, cached device-type attributes, and pass-through sensor factories
- simplify the equivalent resolved-device-name condition

## Why

The description key already identifies the parsed-data field. Repeating that key inside a unique `lambda data: data.get(...)` allocated 99 callback objects during import, added an indirect call to every value read, and created two sources of truth that could drift apart.

The remaining five callbacks are intentional: they round shunt values, derive shunt status, or convert lifetime energy units. Everything else now follows one direct lookup path.

The audit also found definitions and attributes with no production readers. Removing those reduces maintenance surface without changing entities or device behavior.

## Compatibility

- entity keys, unique IDs, names, units, precision, categories, and register writes are unchanged
- transformed sensor behavior is unchanged
- setup still uses the real device when its name is resolved and coordinator-only metadata otherwise
- no Home Assistant lifecycle or BLE transport changes

## Validation

- regression coverage for direct sensor and number lookups
- inverter and smart-battery mapping tests exercise the production entity path
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check . --output-format=github`
- `uv run --no-sync ty check . --output-format=github`
- `uv run --no-sync python -m pytest tests -q` — 85 passed
- `git diff --check`
