### PR TITLE
feat: add Communication Hub multi-battery support

### DIFF
--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -70,26 +70,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "enabled" if communication_hub_enabled else "disabled",
     )
 
-    coordinator_kwargs = {
-        "hass": hass,
-        "logger": LOGGER,
-        "address": device_address,
-        "scan_interval": scan_interval,
-        "device_type": device_type,
-        "shunt_connection_mode": shunt_connection_mode,
-        "non_shunt_connection_mode": non_shunt_connection_mode,
-        "device_data_callback": lambda device: _handle_device_update(hass, entry, device),
-    }
+    device_data_callback = lambda device: _handle_device_update(hass, entry, device)
 
     if communication_hub_enabled:
         from .hub_coordinator import RenogyHubBluetoothCoordinator
 
         coordinator = RenogyHubBluetoothCoordinator(
-            **coordinator_kwargs,
+            hass=hass,
+            logger=LOGGER,
+            address=device_address,
+            scan_interval=scan_interval,
+            device_type=device_type,
+            shunt_connection_mode=shunt_connection_mode,
+            non_shunt_connection_mode=non_shunt_connection_mode,
+            device_data_callback=device_data_callback,
             communication_hub_enabled=True,
         )
     else:
-        coordinator = RenogyActiveBluetoothCoordinator(**coordinator_kwargs)
+        coordinator = RenogyActiveBluetoothCoordinator(
+            hass=hass,
+            logger=LOGGER,
+            address=device_address,
+            scan_interval=scan_interval,
+            device_type=device_type,
+            shunt_connection_mode=shunt_connection_mode,
+            non_shunt_connection_mode=non_shunt_connection_mode,
+            device_data_callback=device_data_callback,
+        )
 
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 

--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -11,10 +11,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 
 from .const import (
+    CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SCAN_INTERVAL,
     CONF_SHUNT_CONNECTION_MODE,
+    DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -51,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_type = entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
     shunt_connection_mode = _get_shunt_connection_mode(entry)
     non_shunt_connection_mode = _get_non_shunt_connection_mode(entry)
+    communication_hub_enabled = _get_communication_hub_enabled(entry)
 
     if not device_address:
         LOGGER.error("No device address provided in config entry")
@@ -58,25 +61,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     LOGGER.info(
         "Configuring Renogy BLE device %s as %s with scan interval %ss "
-        "(shunt mode: %s, non-shunt mode: %s)",
+        "(shunt mode: %s, non-shunt mode: %s, communication hub: %s)",
         device_address,
         device_type,
         scan_interval,
         shunt_connection_mode,
         non_shunt_connection_mode,
+        "enabled" if communication_hub_enabled else "disabled",
     )
 
-    # Create a coordinator for this entry
-    coordinator = RenogyActiveBluetoothCoordinator(
-        hass=hass,
-        logger=LOGGER,
-        address=device_address,
-        scan_interval=scan_interval,
-        device_type=device_type,
-        shunt_connection_mode=shunt_connection_mode,
-        non_shunt_connection_mode=non_shunt_connection_mode,
-        device_data_callback=lambda device: _handle_device_update(hass, entry, device),
-    )
+    coordinator_kwargs = {
+        "hass": hass,
+        "logger": LOGGER,
+        "address": device_address,
+        "scan_interval": scan_interval,
+        "device_type": device_type,
+        "shunt_connection_mode": shunt_connection_mode,
+        "non_shunt_connection_mode": non_shunt_connection_mode,
+        "device_data_callback": lambda device: _handle_device_update(hass, entry, device),
+    }
+
+    if communication_hub_enabled:
+        from .hub_coordinator import RenogyHubBluetoothCoordinator
+
+        coordinator = RenogyHubBluetoothCoordinator(
+            **coordinator_kwargs,
+            communication_hub_enabled=True,
+        )
+    else:
+        coordinator = RenogyActiveBluetoothCoordinator(**coordinator_kwargs)
+
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
     # Store coordinator and devices in hass.data
@@ -128,6 +142,20 @@ def _get_non_shunt_connection_mode(entry: ConfigEntry) -> str:
     return entry.options.get(
         CONF_NON_SHUNT_CONNECTION_MODE,
         DEFAULT_NON_SHUNT_CONNECTION_MODE,
+    )
+
+
+def _get_communication_hub_enabled(entry: ConfigEntry) -> bool:
+    """Return whether Communication Hub battery polling is enabled."""
+    device_type = entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+    if device_type == DeviceType.SHUNT300.value:
+        return False
+
+    return bool(
+        entry.options.get(
+            CONF_COMMUNICATION_HUB_ENABLED,
+            DEFAULT_COMMUNICATION_HUB_ENABLED,
+        )
     )
 
 

--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -10,12 +10,13 @@ from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 
-from . import const as renogy_const
 from .const import (
+    CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SCAN_INTERVAL,
     CONF_SHUNT_CONNECTION_MODE,
+    DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -25,19 +26,6 @@ from .const import (
     DeviceType,
 )
 from .device_name import has_real_device_name
-
-# Keep imports compatible with lightweight test stubs that predate Hub support.
-# The real integration constants define these values identically.
-CONF_COMMUNICATION_HUB_ENABLED = getattr(
-    renogy_const,
-    "CONF_COMMUNICATION_HUB_ENABLED",
-    "communication_hub_enabled",
-)
-DEFAULT_COMMUNICATION_HUB_ENABLED = getattr(
-    renogy_const,
-    "DEFAULT_COMMUNICATION_HUB_ENABLED",
-    False,
-)
 
 if TYPE_CHECKING:
     from .ble import RenogyBLEDevice

--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -70,7 +70,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "enabled" if communication_hub_enabled else "disabled",
     )
 
-    device_data_callback = lambda device: _handle_device_update(hass, entry, device)
+    async def device_data_callback(device: RenogyBLEDevice) -> None:
+        """Forward coordinator device updates to the integration handler."""
+        await _handle_device_update(hass, entry, device)
 
     if communication_hub_enabled:
         from .hub_coordinator import RenogyHubBluetoothCoordinator

--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -10,13 +10,12 @@ from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 
+from . import const as renogy_const
 from .const import (
-    CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SCAN_INTERVAL,
     CONF_SHUNT_CONNECTION_MODE,
-    DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -26,6 +25,19 @@ from .const import (
     DeviceType,
 )
 from .device_name import has_real_device_name
+
+# Keep imports compatible with lightweight test stubs that predate Hub support.
+# The real integration constants define these values identically.
+CONF_COMMUNICATION_HUB_ENABLED = getattr(
+    renogy_const,
+    "CONF_COMMUNICATION_HUB_ENABLED",
+    "communication_hub_enabled",
+)
+DEFAULT_COMMUNICATION_HUB_ENABLED = getattr(
+    renogy_const,
+    "DEFAULT_COMMUNICATION_HUB_ENABLED",
+    False,
+)
 
 if TYPE_CHECKING:
     from .ble import RenogyBLEDevice

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -18,9 +18,11 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
 
 from .const import (
+    CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SHUNT_CONNECTION_MODE,
+    DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -90,14 +92,21 @@ def _build_shunt_options_schema(default_mode: str) -> vol.Schema:
     )
 
 
-def _build_non_shunt_options_schema(default_mode: str) -> vol.Schema:
-    """Build the non-shunt connection mode schema."""
+def _build_non_shunt_options_schema(
+    default_mode: str,
+    default_hub_enabled: bool,
+) -> vol.Schema:
+    """Build non-shunt connection and Communication Hub options."""
     return vol.Schema(
         {
             vol.Required(
                 CONF_NON_SHUNT_CONNECTION_MODE,
                 default=default_mode,
-            ): vol.In(NON_SHUNT_CONNECTION_MODES)
+            ): vol.In(NON_SHUNT_CONNECTION_MODES),
+            vol.Required(
+                CONF_COMMUNICATION_HUB_ENABLED,
+                default=default_hub_enabled,
+            ): bool,
         }
     )
 
@@ -383,7 +392,14 @@ class RenogyOptionsFlowHandler(OptionsFlow):
             CONF_NON_SHUNT_CONNECTION_MODE,
             DEFAULT_NON_SHUNT_CONNECTION_MODE,
         )
+        current_hub_enabled = self._config_entry.options.get(
+            CONF_COMMUNICATION_HUB_ENABLED,
+            DEFAULT_COMMUNICATION_HUB_ENABLED,
+        )
         return self.async_show_form(
             step_id="init",
-            data_schema=_build_non_shunt_options_schema(current_mode),
+            data_schema=_build_non_shunt_options_schema(
+                current_mode,
+                current_hub_enabled,
+            ),
         )

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -22,6 +22,8 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_DEVICE_TYPE = "device_type"  # New constant for device type
 CONF_SHUNT_CONNECTION_MODE = "shunt_connection_mode"
 CONF_NON_SHUNT_CONNECTION_MODE = "non_shunt_connection_mode"
+CONF_COMMUNICATION_HUB_ENABLED = "communication_hub_enabled"
+DEFAULT_COMMUNICATION_HUB_ENABLED = False
 
 # Device info
 ATTR_MANUFACTURER = "Renogy"

--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -1,0 +1,109 @@
+"""Bridge Communication Hub battery telemetry into Home Assistant-safe state."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Any
+
+HubFactory = Callable[[Any], Any]
+
+
+@dataclass(frozen=True, slots=True)
+class RenogyHubBatteryState:
+    """Validated read-only telemetry for one Communication Hub battery."""
+
+    slave_id: int
+    battery_voltage: float | None
+    battery_remaining_capacity: float | None
+    battery_capacity: float | None
+    battery_percentage: float | None
+    available: bool = True
+
+    def as_dict(self) -> dict[str, float | int | None]:
+        """Return only fields independently validated against Hub hardware."""
+        return {
+            "slave_id": self.slave_id,
+            "battery_voltage": self.battery_voltage,
+            "battery_remaining_capacity": self.battery_remaining_capacity,
+            "battery_capacity": self.battery_capacity,
+            "battery_percentage": self.battery_percentage,
+        }
+
+
+def hub_battery_identifier(address: str, slave_id: int) -> str:
+    """Return a stable logical device identifier below one physical BLE address."""
+    return f"{address}:hub:{slave_id:02X}"
+
+
+class RenogyHubBatteryManager:
+    """Cache read-only logical battery state from a Renogy Communication Hub."""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        hub_factory: HubFactory | None = None,
+    ) -> None:
+        """Initialize the Hub state manager."""
+        factory = hub_factory or self._load_hub_factory()
+        self._hub = factory(client)
+        self._batteries: dict[int, RenogyHubBatteryState] = {}
+        self.last_error: Exception | None = None
+
+    @staticmethod
+    def _load_hub_factory() -> HubFactory:
+        """Load Hub support lazily so older renogy-ble releases still import."""
+        hub_module = importlib.import_module("renogy_ble.hub")
+        return hub_module.RenogyCommunicationHub
+
+    @property
+    def batteries(self) -> tuple[RenogyHubBatteryState, ...]:
+        """Return cached batteries ordered by Modbus slave ID."""
+        return tuple(self._batteries[key] for key in sorted(self._batteries))
+
+    def get_battery(self, slave_id: int) -> RenogyHubBatteryState | None:
+        """Return cached state for one Hub battery."""
+        return self._batteries.get(slave_id)
+
+    async def async_update(self, device: Any, *, rediscover: bool = False) -> bool:
+        """Read Hub batteries and refresh the validated logical-device cache."""
+        result = await self._hub.read_batteries(device, rediscover=rediscover)
+        self.last_error = result.error
+
+        seen_slave_ids: set[int] = set()
+        for battery in result.batteries:
+            state = self._state_from_battery(battery)
+            seen_slave_ids.add(state.slave_id)
+            self._batteries[state.slave_id] = state
+
+        for slave_id, state in tuple(self._batteries.items()):
+            if slave_id not in seen_slave_ids:
+                self._batteries[slave_id] = replace(state, available=False)
+
+        return bool(result.success)
+
+    @staticmethod
+    def _state_from_battery(battery: Any) -> RenogyHubBatteryState:
+        """Copy only independently validated fields from a library Hub battery."""
+        data = battery.parsed_data
+        return RenogyHubBatteryState(
+            slave_id=int(battery.slave_id),
+            battery_voltage=_optional_float(data.get("battery_voltage")),
+            battery_remaining_capacity=_optional_float(
+                data.get("battery_remaining_capacity")
+            ),
+            battery_capacity=_optional_float(data.get("battery_capacity")),
+            battery_percentage=_optional_float(data.get("battery_percentage")),
+        )
+
+
+def _optional_float(value: Any) -> float | None:
+    """Return a float for numeric Hub telemetry, otherwise None."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -105,5 +105,5 @@ def _optional_float(value: Any) -> float | None:
         return None
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None

--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -105,5 +105,5 @@ def _optional_float(value: Any) -> float | None:
         return None
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None

--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -67,6 +67,12 @@ class RenogyHubBatteryManager:
         """Return cached state for one Hub battery."""
         return self._batteries.get(slave_id)
 
+    def mark_unavailable(self, error: Exception) -> None:
+        """Retain cached telemetry while marking every Hub battery unavailable."""
+        self.last_error = error
+        for slave_id, state in tuple(self._batteries.items()):
+            self._batteries[slave_id] = replace(state, available=False)
+
     async def async_update(self, device: Any, *, rediscover: bool = False) -> bool:
         """Read Hub batteries and refresh the validated logical-device cache."""
         result = await self._hub.read_batteries(device, rediscover=rediscover)

--- a/custom_components/renogy/hub_coordinator.py
+++ b/custom_components/renogy/hub_coordinator.py
@@ -41,11 +41,7 @@ class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
     async def _read_device_data(self, service_info: Any) -> bool:
         """Read the primary device, then poll Hub batteries when enabled."""
         success = await super()._read_device_data(service_info)
-        if (
-            not success
-            or self._hub_battery_manager is None
-            or self.device is None
-        ):
+        if not success or self._hub_battery_manager is None or self.device is None:
             return success
 
         await self._async_update_hub_batteries(self.device)

--- a/custom_components/renogy/hub_coordinator.py
+++ b/custom_components/renogy/hub_coordinator.py
@@ -1,0 +1,92 @@
+"""Hub-aware coordinator extension for Renogy BLE devices."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
+from .hub import RenogyHubBatteryManager, RenogyHubBatteryState
+
+HubManagerFactory = Callable[[Any], RenogyHubBatteryManager]
+
+
+class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
+    """Extend the normal coordinator with opt-in Hub battery polling."""
+
+    def __init__(
+        self,
+        *args: Any,
+        communication_hub_enabled: bool = False,
+        hub_manager_factory: HubManagerFactory | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the coordinator and optional Communication Hub manager."""
+        super().__init__(*args, **kwargs)
+        self.communication_hub_enabled = communication_hub_enabled
+        self._hub_discovery_complete = False
+        self._hub_battery_manager: RenogyHubBatteryManager | None = None
+
+        if communication_hub_enabled:
+            factory = hub_manager_factory or RenogyHubBatteryManager
+            self._hub_battery_manager = factory(self._ble_client)
+
+    @property
+    def hub_batteries(self) -> tuple[RenogyHubBatteryState, ...]:
+        """Return cached logical batteries discovered through the Hub."""
+        if self._hub_battery_manager is None:
+            return ()
+        return self._hub_battery_manager.batteries
+
+    async def _read_device_data(self, service_info: Any) -> bool:
+        """Read the primary device, then poll Hub batteries when enabled."""
+        success = await super()._read_device_data(service_info)
+        if (
+            not success
+            or self._hub_battery_manager is None
+            or self.device is None
+        ):
+            return success
+
+        await self._async_update_hub_batteries(self.device)
+        return success
+
+    async def _async_update_hub_batteries(
+        self,
+        device: RenogyBLEDevice,
+        *,
+        rediscover: bool | None = None,
+    ) -> bool:
+        """Refresh Hub battery state without changing primary-device availability."""
+        manager = self._hub_battery_manager
+        if manager is None:
+            return False
+
+        if rediscover is None:
+            rediscover = not self._hub_discovery_complete
+
+        try:
+            updated = await manager.async_update(device, rediscover=rediscover)
+        except Exception as err:  # noqa: BLE001
+            self._hub_discovery_complete = True
+            self.logger.warning(
+                "Communication Hub battery read failed for %s: %s",
+                device.address,
+                err,
+            )
+            return False
+
+        self._hub_discovery_complete = True
+        if not updated and manager.last_error is not None:
+            self.logger.debug(
+                "Communication Hub battery read returned no update for %s: %s",
+                device.address,
+                manager.last_error,
+            )
+        return updated
+
+    async def async_rediscover_hub_batteries(self) -> bool:
+        """Explicitly rescan the bounded Hub slave range for battery changes."""
+        if self._hub_battery_manager is None or self.device is None:
+            return False
+        return await self._async_update_hub_batteries(self.device, rediscover=True)

--- a/custom_components/renogy/hub_coordinator.py
+++ b/custom_components/renogy/hub_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -9,6 +10,7 @@ from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .hub import RenogyHubBatteryManager, RenogyHubBatteryState
 
 HubManagerFactory = Callable[[Any], RenogyHubBatteryManager]
+HUB_REDISCOVERY_INTERVAL_SECONDS = 60 * 60
 
 
 class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
@@ -24,7 +26,7 @@ class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
         """Initialize the coordinator and optional Communication Hub manager."""
         super().__init__(*args, **kwargs)
         self.communication_hub_enabled = communication_hub_enabled
-        self._hub_discovery_complete = False
+        self._last_hub_discovery: float | None = None
         self._hub_battery_manager: RenogyHubBatteryManager | None = None
 
         if communication_hub_enabled:
@@ -59,27 +61,38 @@ class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
             return False
 
         if rediscover is None:
-            rediscover = not self._hub_discovery_complete
-
-        try:
-            updated = await manager.async_update(device, rediscover=rediscover)
-        except Exception as err:  # noqa: BLE001
-            self._hub_discovery_complete = True
-            self.logger.warning(
-                "Communication Hub battery read failed for %s: %s",
-                device.address,
-                err,
+            now = time.monotonic()
+            rediscover = (
+                self._last_hub_discovery is None
+                or now - self._last_hub_discovery >= HUB_REDISCOVERY_INTERVAL_SECONDS
             )
-            return False
 
-        self._hub_discovery_complete = True
-        if not updated and manager.last_error is not None:
-            self.logger.debug(
-                "Communication Hub battery read returned no update for %s: %s",
-                device.address,
-                manager.last_error,
-            )
-        return updated
+        # The parent read releases the base coordinator lock before reaching this
+        # extension. Reacquire it so Hub reads cannot overlap refreshes or writes.
+        async with self._connection_lock:
+            self._connection_in_progress = True
+            try:
+                if rediscover:
+                    self._last_hub_discovery = time.monotonic()
+                updated = await manager.async_update(device, rediscover=rediscover)
+            except Exception as err:  # noqa: BLE001
+                manager.mark_unavailable(err)
+                self.logger.warning(
+                    "Communication Hub battery read failed for %s: %s",
+                    device.address,
+                    err,
+                )
+                return False
+            finally:
+                self._connection_in_progress = False
+
+            if not updated and manager.last_error is not None:
+                self.logger.debug(
+                    "Communication Hub battery read returned no update for %s: %s",
+                    device.address,
+                    manager.last_error,
+                )
+            return updated
 
     async def async_rediscover_hub_batteries(self) -> bool:
         """Explicitly rescan the bounded Hub slave range for battery changes."""

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -1,0 +1,154 @@
+"""Sensors for logical batteries connected through a Renogy Communication Hub."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, UnitOfElectricPotential
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ATTR_MANUFACTURER, DOMAIN
+from .hub import RenogyHubBatteryState, hub_battery_identifier
+
+HUB_BATTERY_SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="battery_voltage",
+        name="Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_remaining_capacity",
+        name="Remaining Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+    ),
+    SensorEntityDescription(
+        key="battery_capacity",
+        name="Nominal Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+    ),
+    SensorEntityDescription(
+        key="battery_percentage",
+        name="State of Charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+)
+
+
+def setup_hub_battery_sensors(
+    config_entry: ConfigEntry,
+    coordinator: Any,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add logical Hub battery sensors as responder slave IDs are discovered."""
+    if getattr(coordinator, "communication_hub_enabled", False) is not True:
+        return
+
+    initialized_slave_ids: set[int] = set()
+
+    @callback
+    def _add_discovered_batteries() -> None:
+        new_entities: list[RenogyHubBatterySensor] = []
+        for battery in coordinator.hub_batteries:
+            if battery.slave_id in initialized_slave_ids:
+                continue
+
+            initialized_slave_ids.add(battery.slave_id)
+            new_entities.extend(
+                RenogyHubBatterySensor(
+                    coordinator=coordinator,
+                    slave_id=battery.slave_id,
+                    description=description,
+                )
+                for description in HUB_BATTERY_SENSORS
+            )
+
+        if new_entities:
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_add_discovered_batteries))
+    _add_discovered_batteries()
+
+
+class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
+    """Sensor backed by one logical battery behind a Communication Hub."""
+
+    entity_description: SensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: Any,
+        slave_id: int,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize one validated Hub battery sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._slave_id = slave_id
+        logical_id = hub_battery_identifier(coordinator.address, slave_id)
+
+        self._attr_has_entity_name = True
+        self._attr_name = description.name
+        self._attr_unique_id = f"{logical_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, logical_id)},
+            name=f"Renogy Hub Battery 0x{slave_id:02X}",
+            manufacturer=ATTR_MANUFACTURER,
+            via_device=(DOMAIN, coordinator.address),
+        )
+
+    @property
+    def _battery(self) -> RenogyHubBatteryState | None:
+        """Return the latest cached state for this slave ID."""
+        for battery in self.coordinator.hub_batteries:
+            if battery.slave_id == self._slave_id:
+                return battery
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return whether the parent poll and this logical battery are available."""
+        battery = self._battery
+        return bool(
+            self.coordinator.last_update_success
+            and battery is not None
+            and battery.available
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return this sensor's validated value from the Hub cache."""
+        battery = self._battery
+        if battery is None:
+            return None
+        key = self.entity_description.key
+        if key is None:
+            return None
+        value = getattr(battery, key, None)
+        return float(value) if value is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Expose the validated Modbus slave ID for diagnostics."""
+        return {"slave_id": f"0x{self._slave_id:02X}"}

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -87,7 +87,9 @@ def setup_hub_battery_sensors(
         if new_entities:
             async_add_entities(new_entities)
 
-    config_entry.async_on_unload(coordinator.async_add_listener(_add_discovered_batteries))
+    config_entry.async_on_unload(
+        coordinator.async_add_listener(_add_discovered_batteries)
+    )
     _add_discovered_batteries()
 
 

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
@@ -111,7 +111,7 @@ class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
         logical_id = hub_battery_identifier(coordinator.address, slave_id)
 
         self._attr_has_entity_name = True
-        self._attr_name = description.name
+        self._attr_name = cast(str | None, description.name)
         self._attr_unique_id = f"{logical_id}_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, logical_id)},
@@ -123,7 +123,8 @@ class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
     @property
     def _battery(self) -> RenogyHubBatteryState | None:
         """Return the latest cached state for this slave ID."""
-        for battery in self.coordinator.hub_batteries:
+        coordinator = cast(Any, self.coordinator)
+        for battery in coordinator.hub_batteries:
             if battery.slave_id == self._slave_id:
                 return battery
         return None
@@ -132,8 +133,9 @@ class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
     def available(self) -> bool:
         """Return whether the parent poll and this logical battery are available."""
         battery = self._battery
+        coordinator = cast(Any, self.coordinator)
         return bool(
-            self.coordinator.last_update_success
+            coordinator.last_update_success
             and battery is not None
             and battery.available
         )

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -134,8 +134,10 @@ class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
         """Return whether the parent poll and this logical battery are available."""
         battery = self._battery
         coordinator = cast(Any, self.coordinator)
+        parent_device = coordinator.device
         return bool(
-            coordinator.last_update_success
+            parent_device is not None
+            and parent_device.is_available
             and battery is not None
             and battery.available
         )

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -35,7 +35,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.4.1"
+    "renogy-ble@git+https://github.com/codefendant/renogy-ble.git@3caac09082130e2c0c43a4526adc33aff24fba7e"
   ],
   "version": "0.8.0"
 }

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -39,6 +39,7 @@ from .const import (
     LOGGER,
     DeviceType,
 )
+from .hub_sensor import setup_hub_battery_sensors
 
 # Registry of sensor keys
 KEY_BATTERY_VOLTAGE = "battery_voltage"
@@ -952,6 +953,14 @@ async def async_setup_entry(
         async_add_entities(device_entities)
     else:
         LOGGER.warning("No entities were created")
+
+    # Add logical child-battery entities for Communication Hub responders.
+    # The helper exits immediately when Hub support is disabled.
+    setup_hub_battery_sensors(
+        config_entry,
+        coordinator,
+        async_add_entities,
+    )
 
 
 def create_entities_helper(

--- a/custom_components/renogy/strings.json
+++ b/custom_components/renogy/strings.json
@@ -33,7 +33,8 @@
       "init": {
         "data": {
           "shunt_connection_mode": "Smart Shunt connection mode",
-          "non_shunt_connection_mode": "Non-shunt connection mode"
+          "non_shunt_connection_mode": "Non-shunt connection mode",
+          "communication_hub_enabled": "Communication Hub / multiple batteries"
         }
       }
     }

--- a/custom_components/renogy/translations/en.json
+++ b/custom_components/renogy/translations/en.json
@@ -33,7 +33,8 @@
       "init": {
         "data": {
           "shunt_connection_mode": "Smart Shunt connection mode",
-          "non_shunt_connection_mode": "Non-shunt connection mode"
+          "non_shunt_connection_mode": "Non-shunt connection mode",
+          "communication_hub_enabled": "Communication Hub / multiple batteries"
         }
       }
     }

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -3,14 +3,36 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
+import sys
+import types
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from custom_components.renogy.hub import (
-    RenogyHubBatteryManager,
-    hub_battery_identifier,
-)
+
+def _load_hub_module() -> Any:
+    """Load hub.py without executing the integration package initializer."""
+    repo_root = Path(__file__).resolve().parents[1]
+    custom_components_path = str(repo_root / "custom_components")
+    renogy_path = str(repo_root / "custom_components" / "renogy")
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [custom_components_path]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    renogy_pkg = types.ModuleType("custom_components.renogy")
+    renogy_pkg.__path__ = [renogy_path]
+    sys.modules["custom_components.renogy"] = renogy_pkg
+
+    sys.modules.pop("custom_components.renogy.hub", None)
+    return importlib.import_module("custom_components.renogy.hub")
+
+
+hub_module = _load_hub_module()
+RenogyHubBatteryManager = hub_module.RenogyHubBatteryManager
+hub_battery_identifier = hub_module.hub_battery_identifier
 
 
 @dataclass
@@ -39,7 +61,7 @@ def _battery(slave_id: int, **data: Any) -> Any:
     return SimpleNamespace(slave_id=slave_id, parsed_data=data)
 
 
-def _manager(results: list[_FakeResult]) -> tuple[RenogyHubBatteryManager, _FakeHub]:
+def _manager(results: list[_FakeResult]) -> tuple[Any, _FakeHub]:
     fake_hub = _FakeHub(results)
     manager = RenogyHubBatteryManager(
         object(),

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,189 @@
+"""Tests for Communication Hub logical battery state management."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from custom_components.renogy.hub import (
+    RenogyHubBatteryManager,
+    hub_battery_identifier,
+)
+
+
+@dataclass
+class _FakeResult:
+    success: bool
+    batteries: list[Any]
+    error: Exception | None = None
+
+
+class _FakeHub:
+    def __init__(self, results: list[_FakeResult]) -> None:
+        self._results = list(results)
+        self.calls: list[bool] = []
+
+    async def read_batteries(
+        self,
+        _device: Any,
+        *,
+        rediscover: bool = False,
+    ) -> _FakeResult:
+        self.calls.append(rediscover)
+        return self._results.pop(0)
+
+
+def _battery(slave_id: int, **data: Any) -> Any:
+    return SimpleNamespace(slave_id=slave_id, parsed_data=data)
+
+
+def _manager(results: list[_FakeResult]) -> tuple[RenogyHubBatteryManager, _FakeHub]:
+    fake_hub = _FakeHub(results)
+    manager = RenogyHubBatteryManager(
+        object(),
+        hub_factory=lambda _client: fake_hub,
+    )
+    return manager, fake_hub
+
+
+def test_hub_manager_caches_only_validated_fields() -> None:
+    """Unvalidated current and power values must not enter HA Hub state."""
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=49.8,
+                        battery_remaining_capacity=42.389,
+                        battery_capacity=49.995,
+                        battery_percentage=84.8,
+                        battery_current=123.45,
+                        battery_power=6789,
+                    )
+                ],
+            )
+        ]
+    )
+
+    assert asyncio.run(manager.async_update(object())) is True
+
+    battery = manager.get_battery(0x30)
+    assert battery is not None
+    assert battery.available is True
+    assert battery.as_dict() == {
+        "slave_id": 0x30,
+        "battery_voltage": 49.8,
+        "battery_remaining_capacity": 42.389,
+        "battery_capacity": 49.995,
+        "battery_percentage": 84.8,
+    }
+    assert "battery_current" not in battery.as_dict()
+    assert "battery_power" not in battery.as_dict()
+
+
+def test_hub_manager_marks_missing_cached_battery_unavailable() -> None:
+    """A missed cached slave should retain its last values but become unavailable."""
+    timeout_error = TimeoutError("battery timeout")
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(0x30, battery_voltage=49.8, battery_percentage=84.8),
+                    _battery(0x31, battery_voltage=49.8, battery_percentage=91.9),
+                ],
+            ),
+            _FakeResult(
+                True,
+                [_battery(0x30, battery_voltage=49.7, battery_percentage=84.6)],
+                timeout_error,
+            ),
+        ]
+    )
+
+    async def _run() -> None:
+        assert await manager.async_update(object()) is True
+        assert await manager.async_update(object()) is True
+
+    asyncio.run(_run())
+
+    battery_30 = manager.get_battery(0x30)
+    battery_31 = manager.get_battery(0x31)
+    assert battery_30 is not None and battery_30.available is True
+    assert battery_30.battery_voltage == 49.7
+    assert battery_31 is not None and battery_31.available is False
+    assert battery_31.battery_percentage == 91.9
+    assert manager.last_error is timeout_error
+
+
+def test_hub_manager_rediscovery_adds_new_slave() -> None:
+    """Explicit rediscovery should add newly responding logical batteries."""
+    manager, fake_hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(0x30, battery_voltage=49.8),
+                    _battery(0x31, battery_voltage=49.8),
+                ],
+            ),
+            _FakeResult(
+                True,
+                [
+                    _battery(0x30, battery_voltage=49.8),
+                    _battery(0x31, battery_voltage=49.8),
+                    _battery(0x32, battery_voltage=49.8),
+                ],
+            ),
+        ]
+    )
+
+    async def _run() -> None:
+        assert await manager.async_update(object()) is True
+        assert await manager.async_update(object(), rediscover=True) is True
+
+    asyncio.run(_run())
+
+    assert fake_hub.calls == [False, True]
+    assert [battery.slave_id for battery in manager.batteries] == [0x30, 0x31, 0x32]
+
+
+def test_hub_manager_handles_non_numeric_optional_values() -> None:
+    """Malformed optional telemetry should be ignored rather than propagated."""
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage="49.8",
+                        battery_remaining_capacity="bad",
+                        battery_capacity=None,
+                        battery_percentage="84.8",
+                    )
+                ],
+            )
+        ]
+    )
+
+    asyncio.run(manager.async_update(object()))
+
+    battery = manager.get_battery(0x30)
+    assert battery is not None
+    assert battery.battery_voltage == 49.8
+    assert battery.battery_remaining_capacity is None
+    assert battery.battery_capacity is None
+    assert battery.battery_percentage == 84.8
+
+
+def test_hub_battery_identifier_is_stable_and_slave_specific() -> None:
+    """Logical battery identifiers should be unique beneath one BLE address."""
+    address = "F0:F8:F2:57:47:0D"
+
+    assert hub_battery_identifier(address, 0x30) == "F0:F8:F2:57:47:0D:hub:30"
+    assert hub_battery_identifier(address, 0x31) == "F0:F8:F2:57:47:0D:hub:31"

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -203,6 +203,28 @@ def test_hub_manager_handles_non_numeric_optional_values() -> None:
     assert battery.battery_percentage == 84.8
 
 
+def test_hub_manager_marks_all_cached_batteries_unavailable() -> None:
+    """A raised Hub transaction should invalidate every cached child battery."""
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(0x30, battery_voltage=49.8),
+                    _battery(0x31, battery_voltage=49.7),
+                ],
+            )
+        ]
+    )
+    asyncio.run(manager.async_update(object()))
+    error = TimeoutError("Hub connection failed")
+
+    manager.mark_unavailable(error)
+
+    assert manager.last_error is error
+    assert all(not battery.available for battery in manager.batteries)
+
+
 def test_hub_battery_identifier_is_stable_and_slave_specific() -> None:
     """Logical battery identifiers should be unique beneath one BLE address."""
     address = "F0:F8:F2:57:47:0D"

--- a/tests/test_hub_coordinator.py
+++ b/tests/test_hub_coordinator.py
@@ -7,7 +7,6 @@ import importlib
 import sys
 import types
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 

--- a/tests/test_hub_coordinator.py
+++ b/tests/test_hub_coordinator.py
@@ -1,0 +1,177 @@
+"""Tests for opt-in Communication Hub coordinator behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+
+def _load_hub_coordinator_module() -> Any:
+    """Load hub_coordinator.py with isolated integration dependencies."""
+    repo_root = Path(__file__).resolve().parents[1]
+    custom_components_path = str(repo_root / "custom_components")
+    renogy_path = str(repo_root / "custom_components" / "renogy")
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [custom_components_path]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    renogy_pkg = types.ModuleType("custom_components.renogy")
+    renogy_pkg.__path__ = [renogy_path]
+    sys.modules["custom_components.renogy"] = renogy_pkg
+
+    ble_module = cast(Any, types.ModuleType("custom_components.renogy.ble"))
+
+    class RenogyBLEDevice:
+        """Minimal logical BLE device used by coordinator tests."""
+
+        def __init__(self, address: str = "AA:BB:CC:DD:EE:FF") -> None:
+            self.address = address
+
+    class RenogyActiveBluetoothCoordinator:
+        """Minimal base coordinator exposing primary-read behavior."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._ble_client = object()
+            self.device = RenogyBLEDevice(kwargs.get("address", "AA:BB:CC:DD:EE:FF"))
+            self.logger = MagicMock()
+            self.last_update_success = True
+            self.primary_success = True
+
+        async def _read_device_data(self, _service_info: Any) -> bool:
+            self.last_update_success = self.primary_success
+            return self.primary_success
+
+    ble_module.RenogyBLEDevice = RenogyBLEDevice
+    ble_module.RenogyActiveBluetoothCoordinator = RenogyActiveBluetoothCoordinator
+    sys.modules["custom_components.renogy.ble"] = ble_module
+
+    hub_module = cast(Any, types.ModuleType("custom_components.renogy.hub"))
+
+    class RenogyHubBatteryState:
+        """Minimal cached Hub state placeholder."""
+
+    class RenogyHubBatteryManager:
+        """Default manager placeholder; tests inject a fake manager factory."""
+
+        def __init__(self, _client: Any) -> None:
+            raise AssertionError("Tests should inject a Hub manager factory")
+
+    hub_module.RenogyHubBatteryState = RenogyHubBatteryState
+    hub_module.RenogyHubBatteryManager = RenogyHubBatteryManager
+    sys.modules["custom_components.renogy.hub"] = hub_module
+
+    sys.modules.pop("custom_components.renogy.hub_coordinator", None)
+    return importlib.import_module("custom_components.renogy.hub_coordinator")
+
+
+class _FakeHubManager:
+    """Record coordinator Hub update requests."""
+
+    def __init__(
+        self,
+        *,
+        results: list[bool] | None = None,
+        error: Exception | None = None,
+        batteries: tuple[Any, ...] = (),
+    ) -> None:
+        self._results = list(results or [True])
+        self._error = error
+        self.batteries = batteries
+        self.last_error: Exception | None = None
+        self.calls: list[bool] = []
+
+    async def async_update(self, _device: Any, *, rediscover: bool = False) -> bool:
+        self.calls.append(rediscover)
+        if self._error is not None:
+            raise self._error
+        result = self._results.pop(0)
+        if not result:
+            self.last_error = RuntimeError("Hub returned no battery update")
+        return result
+
+
+def _coordinator(module: Any, manager: _FakeHubManager, *, enabled: bool = True) -> Any:
+    """Create a Hub-aware coordinator using the supplied fake manager."""
+    return module.RenogyHubBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        communication_hub_enabled=enabled,
+        hub_manager_factory=lambda _client: manager,
+    )
+
+
+def test_hub_coordinator_is_disabled_by_default() -> None:
+    """Default coordinator behavior must not create or poll a Hub manager."""
+    module = _load_hub_coordinator_module()
+    coordinator = module.RenogyHubBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+    )
+
+    assert coordinator.communication_hub_enabled is False
+    assert coordinator.hub_batteries == ()
+    assert asyncio.run(coordinator._read_device_data(object())) is True
+
+
+def test_hub_coordinator_discovers_once_then_uses_cached_polling() -> None:
+    """First Hub read should rediscover, while later reads use cached slaves."""
+    module = _load_hub_coordinator_module()
+    manager = _FakeHubManager(results=[True, True])
+    coordinator = _coordinator(module, manager)
+
+    async def _run() -> None:
+        assert await coordinator._read_device_data(object()) is True
+        assert await coordinator._read_device_data(object()) is True
+
+    asyncio.run(_run())
+
+    assert manager.calls == [True, False]
+
+
+def test_hub_coordinator_skips_hub_when_primary_read_fails() -> None:
+    """A failed primary device read must not start a Hub battery transaction."""
+    module = _load_hub_coordinator_module()
+    manager = _FakeHubManager()
+    coordinator = _coordinator(module, manager)
+    coordinator.primary_success = False
+
+    assert asyncio.run(coordinator._read_device_data(object())) is False
+    assert manager.calls == []
+    assert coordinator.last_update_success is False
+
+
+def test_hub_failure_does_not_mark_primary_device_unavailable() -> None:
+    """Hub read exceptions must not turn a successful inverter poll into failure."""
+    module = _load_hub_coordinator_module()
+    manager = _FakeHubManager(error=RuntimeError("Hub timeout"))
+    coordinator = _coordinator(module, manager)
+
+    assert asyncio.run(coordinator._read_device_data(object())) is True
+
+    assert coordinator.last_update_success is True
+    assert manager.calls == [True]
+    coordinator.logger.warning.assert_called_once()
+
+
+def test_hub_coordinator_supports_explicit_rediscovery() -> None:
+    """Explicit rediscovery should force a new bounded Hub slave scan."""
+    module = _load_hub_coordinator_module()
+    manager = _FakeHubManager(results=[True, True])
+    coordinator = _coordinator(module, manager)
+
+    async def _run() -> None:
+        assert await coordinator._read_device_data(object()) is True
+        assert await coordinator.async_rediscover_hub_batteries() is True
+
+    asyncio.run(_run())
+
+    assert manager.calls == [True, True]

--- a/tests/test_hub_coordinator.py
+++ b/tests/test_hub_coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
+import time
 import types
 from pathlib import Path
 from typing import Any, cast
@@ -38,6 +39,8 @@ def _load_hub_coordinator_module() -> Any:
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             self._ble_client = object()
+            self._connection_lock = asyncio.Lock()
+            self._connection_in_progress = False
             self.device = RenogyBLEDevice(kwargs.get("address", "AA:BB:CC:DD:EE:FF"))
             self.logger = MagicMock()
             self.last_update_success = True
@@ -85,6 +88,12 @@ class _FakeHubManager:
         self.batteries = batteries
         self.last_error: Exception | None = None
         self.calls: list[bool] = []
+        self.unavailable_errors: list[Exception] = []
+
+    def mark_unavailable(self, error: Exception) -> None:
+        """Record invalidation of cached Hub battery state."""
+        self.last_error = error
+        self.unavailable_errors.append(error)
 
     async def async_update(self, _device: Any, *, rediscover: bool = False) -> bool:
         self.calls.append(rediscover)
@@ -158,6 +167,7 @@ def test_hub_failure_does_not_mark_primary_device_unavailable() -> None:
 
     assert coordinator.last_update_success is True
     assert manager.calls == [True]
+    assert manager.unavailable_errors == [manager._error]
     coordinator.logger.warning.assert_called_once()
 
 
@@ -174,3 +184,40 @@ def test_hub_coordinator_supports_explicit_rediscovery() -> None:
     asyncio.run(_run())
 
     assert manager.calls == [True, True]
+
+
+def test_hub_coordinator_periodically_rediscovers_batteries() -> None:
+    """A later poll should rescan for batteries missed during initial discovery."""
+    module = _load_hub_coordinator_module()
+    manager = _FakeHubManager(results=[True, True, True])
+    coordinator = _coordinator(module, manager)
+
+    async def _run() -> None:
+        assert await coordinator._read_device_data(object()) is True
+        assert await coordinator._read_device_data(object()) is True
+        coordinator._last_hub_discovery = (
+            time.monotonic() - module.HUB_REDISCOVERY_INTERVAL_SECONDS
+        )
+        assert await coordinator._read_device_data(object()) is True
+
+    asyncio.run(_run())
+
+    assert manager.calls == [True, False, True]
+
+
+def test_hub_transaction_holds_coordinator_connection_guard() -> None:
+    """Hub I/O should remain serialized with parent refreshes and writes."""
+    module = _load_hub_coordinator_module()
+
+    class GuardCheckingManager(_FakeHubManager):
+        async def async_update(self, _device: Any, *, rediscover: bool = False) -> bool:
+            assert coordinator._connection_lock.locked()
+            assert coordinator._connection_in_progress is True
+            return await super().async_update(_device, rediscover=rediscover)
+
+    manager = GuardCheckingManager()
+    coordinator = _coordinator(module, manager)
+
+    assert asyncio.run(coordinator._read_device_data(object())) is True
+    assert coordinator._connection_lock.locked() is False
+    assert coordinator._connection_in_progress is False

--- a/tests/test_hub_import.py
+++ b/tests/test_hub_import.py
@@ -1,0 +1,32 @@
+"""Regression tests for importing the production Communication Hub module."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_real_hub_module_imports_in_clean_interpreter() -> None:
+    """Import the production Hub module without any test module stubs."""
+    repo_root = Path(__file__).resolve().parents[1]
+    hub_path = repo_root / "custom_components" / "renogy" / "hub.py"
+    script = f"""
+import importlib
+from pathlib import Path
+
+module = importlib.import_module("custom_components.renogy.hub")
+assert Path(module.__file__).resolve() == Path({str(hub_path)!r}).resolve()
+assert hasattr(module, "RenogyHubBatteryManager")
+assert hasattr(module, "RenogyHubBatteryState")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_hub_import.py
+++ b/tests/test_hub_import.py
@@ -1,4 +1,4 @@
-"""Regression tests for importing the production Communication Hub module."""
+"""Regression tests for loading the production Communication Hub module."""
 
 from __future__ import annotations
 
@@ -8,17 +8,37 @@ from pathlib import Path
 
 
 def test_real_hub_module_imports_in_clean_interpreter() -> None:
-    """Import the production Hub module without any test module stubs."""
+    """Load the production Hub module without package or test-module stubs."""
     repo_root = Path(__file__).resolve().parents[1]
     hub_path = repo_root / "custom_components" / "renogy" / "hub.py"
     script = f"""
-import importlib
+import importlib.util
+import sys
+import types
 from pathlib import Path
 
-module = importlib.import_module("custom_components.renogy.hub")
-assert Path(module.__file__).resolve() == Path({str(hub_path)!r}).resolve()
+hub_path = Path({str(hub_path)!r}).resolve()
+
+custom_components_pkg = types.ModuleType("custom_components")
+custom_components_pkg.__path__ = [str(hub_path.parents[1])]
+sys.modules["custom_components"] = custom_components_pkg
+
+renogy_pkg = types.ModuleType("custom_components.renogy")
+renogy_pkg.__path__ = [str(hub_path.parent)]
+sys.modules["custom_components.renogy"] = renogy_pkg
+
+spec = importlib.util.spec_from_file_location("custom_components.renogy.hub", hub_path)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+assert Path(module.__file__).resolve() == hub_path
+assert module.__name__ == "custom_components.renogy.hub"
 assert hasattr(module, "RenogyHubBatteryManager")
 assert hasattr(module, "RenogyHubBatteryState")
+assert module._optional_float("1.5") == 1.5
+assert module._optional_float(object()) is None
 """
 
     result = subprocess.run(

--- a/tests/test_hub_options.py
+++ b/tests/test_hub_options.py
@@ -1,0 +1,141 @@
+"""Tests for Communication Hub options-flow behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+from tests.test_config_flow import _load_config_flow_module, _schema_default
+
+
+def _entry(
+    const_module: Any,
+    *,
+    device_type: str,
+    options: dict[str, Any] | None = None,
+) -> Any:
+    """Build a minimal config entry for options-flow tests."""
+    return types.SimpleNamespace(
+        data={const_module.CONF_DEVICE_TYPE: device_type},
+        options=options or {},
+    )
+
+
+def _schema_fields(schema: Any) -> set[str]:
+    """Return field names from a voluptuous schema."""
+    return {str(key.schema) for key in schema.schema}
+
+
+def test_non_shunt_hub_option_defaults_to_disabled() -> None:
+    """Existing non-shunt entries should show Hub polling disabled by default."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    handler = config_flow_module.RenogyOptionsFlowHandler(
+        _entry(const_module, device_type=const_module.DeviceType.INVERTER.value)
+    )
+
+    result = asyncio.run(handler.async_step_init())
+
+    assert result["type"] == "form"
+    assert (
+        _schema_default(
+            result["data_schema"],
+            const_module.CONF_COMMUNICATION_HUB_ENABLED,
+        )
+        is False
+    )
+    assert (
+        _schema_default(
+            result["data_schema"],
+            const_module.CONF_NON_SHUNT_CONNECTION_MODE,
+        )
+        == const_module.DEFAULT_NON_SHUNT_CONNECTION_MODE
+    )
+
+
+def test_non_shunt_hub_option_preserves_enabled_value() -> None:
+    """The options form should preserve an already enabled Hub setting."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    handler = config_flow_module.RenogyOptionsFlowHandler(
+        _entry(
+            const_module,
+            device_type=const_module.DeviceType.INVERTER.value,
+            options={
+                const_module.CONF_NON_SHUNT_CONNECTION_MODE: "persistent_session",
+                const_module.CONF_COMMUNICATION_HUB_ENABLED: True,
+            },
+        )
+    )
+
+    result = asyncio.run(handler.async_step_init())
+
+    assert (
+        _schema_default(
+            result["data_schema"],
+            const_module.CONF_COMMUNICATION_HUB_ENABLED,
+        )
+        is True
+    )
+    assert (
+        _schema_default(
+            result["data_schema"],
+            const_module.CONF_NON_SHUNT_CONNECTION_MODE,
+        )
+        == "persistent_session"
+    )
+
+
+def test_non_shunt_hub_option_submission_is_saved() -> None:
+    """Submitting the Hub checkbox should save it with the connection mode."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    handler = config_flow_module.RenogyOptionsFlowHandler(
+        _entry(const_module, device_type=const_module.DeviceType.INVERTER.value)
+    )
+    user_input = {
+        const_module.CONF_NON_SHUNT_CONNECTION_MODE: "persistent_session",
+        const_module.CONF_COMMUNICATION_HUB_ENABLED: True,
+    }
+
+    result = asyncio.run(handler.async_step_init(user_input))
+
+    assert result == {
+        "type": "create_entry",
+        "title": "",
+        "data": user_input,
+    }
+
+
+def test_shunt_options_do_not_expose_hub_checkbox() -> None:
+    """Smart Shunt entries should keep their existing options unchanged."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    handler = config_flow_module.RenogyOptionsFlowHandler(
+        _entry(const_module, device_type=const_module.DeviceType.SHUNT300.value)
+    )
+
+    result = asyncio.run(handler.async_step_init())
+    fields = _schema_fields(result["data_schema"])
+
+    assert const_module.CONF_SHUNT_CONNECTION_MODE in fields
+    assert const_module.CONF_COMMUNICATION_HUB_ENABLED not in fields
+
+
+def test_hub_option_has_user_facing_label() -> None:
+    """English strings should label the Hub option as multiple-battery support."""
+    repo_root = Path(__file__).resolve().parents[1]
+    expected = "Communication Hub / multiple batteries"
+
+    for relative_path in (
+        "custom_components/renogy/strings.json",
+        "custom_components/renogy/translations/en.json",
+    ):
+        strings = json.loads((repo_root / relative_path).read_text())
+        assert strings["options"]["step"]["init"]["data"][
+            "communication_hub_enabled"
+        ] == expected

--- a/tests/test_hub_options.py
+++ b/tests/test_hub_options.py
@@ -136,6 +136,7 @@ def test_hub_option_has_user_facing_label() -> None:
         "custom_components/renogy/translations/en.json",
     ):
         strings = json.loads((repo_root / relative_path).read_text())
-        assert strings["options"]["step"]["init"]["data"][
-            "communication_hub_enabled"
-        ] == expected
+        assert (
+            strings["options"]["step"]["init"]["data"]["communication_hub_enabled"]
+            == expected
+        )

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -72,9 +72,9 @@ def _install_module_stubs() -> None:
     passive_module.PassiveBluetoothCoordinatorEntity = PassiveBluetoothCoordinatorEntity
     sys.modules["homeassistant.components"] = components_module
     sys.modules["homeassistant.components.bluetooth"] = bluetooth_module
-    sys.modules[
-        "homeassistant.components.bluetooth.passive_update_coordinator"
-    ] = passive_module
+    sys.modules["homeassistant.components.bluetooth.passive_update_coordinator"] = (
+        passive_module
+    )
 
     sensor_module = cast(Any, types.ModuleType("homeassistant.components.sensor"))
 
@@ -171,8 +171,8 @@ def _install_module_stubs() -> None:
 
     hub_stub = cast(Any, types.ModuleType("custom_components.renogy.hub"))
     hub_stub.RenogyHubBatteryState = _BatteryState
-    hub_stub.hub_battery_identifier = (
-        lambda address, slave_id: f"{address}:hub:{slave_id:02X}"
+    hub_stub.hub_battery_identifier = lambda address, slave_id: (
+        f"{address}:hub:{slave_id:02X}"
     )
     sys.modules["custom_components.renogy.hub"] = hub_stub
 
@@ -265,10 +265,7 @@ def test_hub_battery_0x33_is_child_device_with_validated_values() -> None:
         module.RenogyHubBatterySensor(coordinator, 0x33, description)
         for description in module.HUB_BATTERY_SENSORS
     ]
-    entities_by_key = {
-        entity.entity_description.key: entity
-        for entity in entities
-    }
+    entities_by_key = {entity.entity_description.key: entity for entity in entities}
 
     assert entities_by_key["battery_voltage"].native_value == 50.4
     assert entities_by_key["battery_remaining_capacity"].native_value == 44.493

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -184,9 +184,10 @@ def _load_hub_sensor_module() -> Any:
 
     module = importlib.import_module("custom_components.renogy.hub_sensor")
 
-    # The Hub model is stubbed only for these focused unit tests.
-    # Remove it after import so unrelated tests see the production module.
+    # Hub-specific imports are scoped to these focused tests. Remove them after
+    # import so unrelated platform tests load the production modules afresh.
     sys.modules.pop("custom_components.renogy.hub", None)
+    sys.modules.pop("custom_components.renogy.const", None)
 
     return module
 

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -1,0 +1,325 @@
+"""Tests for Communication Hub logical battery sensor entities."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+
+@dataclass(frozen=True, slots=True)
+class _BatteryState:
+    slave_id: int
+    battery_voltage: float | None = None
+    battery_remaining_capacity: float | None = None
+    battery_capacity: float | None = None
+    battery_percentage: float | None = None
+    available: bool = True
+
+
+class _Coordinator:
+    def __init__(self) -> None:
+        self.address = "F0:F8:F2:57:47:0D"
+        self.communication_hub_enabled = True
+        self.last_update_success = True
+        self.hub_batteries: tuple[_BatteryState, ...] = ()
+        self.listeners: list[Any] = []
+
+    def async_add_listener(self, callback: Any, context: Any = None) -> Any:
+        del context
+        self.listeners.append(callback)
+
+        def remove_listener() -> None:
+            if callback in self.listeners:
+                self.listeners.remove(callback)
+
+        return remove_listener
+
+    def notify(self) -> None:
+        for listener in tuple(self.listeners):
+            listener()
+
+
+class _ConfigEntry:
+    def __init__(self) -> None:
+        self.unload_callbacks: list[Any] = []
+
+    def async_on_unload(self, callback: Any) -> None:
+        self.unload_callbacks.append(callback)
+
+
+def _install_module_stubs() -> None:
+    homeassistant_module = cast(Any, types.ModuleType("homeassistant"))
+    sys.modules["homeassistant"] = homeassistant_module
+
+    components_module = cast(Any, types.ModuleType("homeassistant.components"))
+    bluetooth_module = cast(Any, types.ModuleType("homeassistant.components.bluetooth"))
+    passive_module = cast(
+        Any,
+        types.ModuleType(
+            "homeassistant.components.bluetooth.passive_update_coordinator"
+        ),
+    )
+
+    class PassiveBluetoothCoordinatorEntity:
+        def __init__(self, coordinator: Any) -> None:
+            self.coordinator = coordinator
+
+    passive_module.PassiveBluetoothCoordinatorEntity = PassiveBluetoothCoordinatorEntity
+    sys.modules["homeassistant.components"] = components_module
+    sys.modules["homeassistant.components.bluetooth"] = bluetooth_module
+    sys.modules[
+        "homeassistant.components.bluetooth.passive_update_coordinator"
+    ] = passive_module
+
+    sensor_module = cast(Any, types.ModuleType("homeassistant.components.sensor"))
+
+    @dataclass(frozen=True)
+    class SensorEntityDescription:
+        key: str
+        name: str | None = None
+        native_unit_of_measurement: str | None = None
+        device_class: str | None = None
+        state_class: str | None = None
+        suggested_display_precision: int | None = None
+
+    class SensorEntity:
+        pass
+
+    class SensorDeviceClass:
+        VOLTAGE = "voltage"
+        BATTERY = "battery"
+
+    class SensorStateClass:
+        MEASUREMENT = "measurement"
+
+    sensor_module.SensorEntity = SensorEntity
+    sensor_module.SensorEntityDescription = SensorEntityDescription
+    sensor_module.SensorDeviceClass = SensorDeviceClass
+    sensor_module.SensorStateClass = SensorStateClass
+    sys.modules["homeassistant.components.sensor"] = sensor_module
+
+    config_entries_module = cast(Any, types.ModuleType("homeassistant.config_entries"))
+
+    class ConfigEntry:
+        pass
+
+    config_entries_module.ConfigEntry = ConfigEntry
+    sys.modules["homeassistant.config_entries"] = config_entries_module
+
+    const_module = cast(Any, types.ModuleType("homeassistant.const"))
+    const_module.PERCENTAGE = "%"
+
+    class UnitOfElectricPotential:
+        VOLT = "V"
+
+    const_module.UnitOfElectricPotential = UnitOfElectricPotential
+    sys.modules["homeassistant.const"] = const_module
+
+    core_module = cast(Any, types.ModuleType("homeassistant.core"))
+
+    def callback(func: Any) -> Any:
+        return func
+
+    core_module.callback = callback
+    sys.modules["homeassistant.core"] = core_module
+
+    helpers_module = cast(Any, types.ModuleType("homeassistant.helpers"))
+    sys.modules["homeassistant.helpers"] = helpers_module
+
+    device_registry_module = cast(
+        Any, types.ModuleType("homeassistant.helpers.device_registry")
+    )
+
+    class DeviceInfo(dict):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+    device_registry_module.DeviceInfo = DeviceInfo
+    sys.modules["homeassistant.helpers.device_registry"] = device_registry_module
+
+    entity_platform_module = cast(
+        Any, types.ModuleType("homeassistant.helpers.entity_platform")
+    )
+
+    class AddEntitiesCallback:
+        pass
+
+    entity_platform_module.AddEntitiesCallback = AddEntitiesCallback
+    sys.modules["homeassistant.helpers.entity_platform"] = entity_platform_module
+
+    repo_root = Path(__file__).resolve().parents[1]
+    custom_components_path = str(repo_root / "custom_components")
+    renogy_path = str(repo_root / "custom_components" / "renogy")
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [custom_components_path]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    renogy_pkg = types.ModuleType("custom_components.renogy")
+    renogy_pkg.__path__ = [renogy_path]
+    sys.modules["custom_components.renogy"] = renogy_pkg
+
+    const_stub = cast(Any, types.ModuleType("custom_components.renogy.const"))
+    const_stub.ATTR_MANUFACTURER = "Renogy"
+    const_stub.DOMAIN = "renogy"
+    sys.modules["custom_components.renogy.const"] = const_stub
+
+    hub_stub = cast(Any, types.ModuleType("custom_components.renogy.hub"))
+    hub_stub.RenogyHubBatteryState = _BatteryState
+    hub_stub.hub_battery_identifier = (
+        lambda address, slave_id: f"{address}:hub:{slave_id:02X}"
+    )
+    sys.modules["custom_components.renogy.hub"] = hub_stub
+
+
+def _load_hub_sensor_module() -> Any:
+    _install_module_stubs()
+    sys.modules.pop("custom_components.renogy.hub_sensor", None)
+    return importlib.import_module("custom_components.renogy.hub_sensor")
+
+
+def test_hub_sensor_descriptions_expose_only_validated_telemetry() -> None:
+    module = _load_hub_sensor_module()
+
+    assert {description.key for description in module.HUB_BATTERY_SENSORS} == {
+        "battery_voltage",
+        "battery_remaining_capacity",
+        "battery_capacity",
+        "battery_percentage",
+    }
+
+
+def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    config_entry = _ConfigEntry()
+    added_batches: list[list[Any]] = []
+
+    module.setup_hub_battery_sensors(
+        config_entry,
+        coordinator,
+        lambda entities: added_batches.append(list(entities)),
+    )
+
+    assert added_batches == []
+    assert len(coordinator.listeners) == 1
+    assert len(config_entry.unload_callbacks) == 1
+
+    coordinator.hub_batteries = (
+        _BatteryState(slave_id=0x30, battery_voltage=50.5),
+        _BatteryState(slave_id=0x33, battery_voltage=50.4),
+    )
+    coordinator.notify()
+
+    assert len(added_batches) == 1
+    assert len(added_batches[0]) == 8
+    assert {entity._slave_id for entity in added_batches[0]} == {0x30, 0x33}
+
+    coordinator.notify()
+    assert len(added_batches) == 1
+
+    coordinator.hub_batteries = (
+        *coordinator.hub_batteries,
+        _BatteryState(slave_id=0x31, battery_voltage=50.5),
+    )
+    coordinator.notify()
+
+    assert len(added_batches) == 2
+    assert len(added_batches[1]) == 4
+    assert {entity._slave_id for entity in added_batches[1]} == {0x31}
+
+
+def test_hub_battery_0x33_is_child_device_with_validated_values() -> None:
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.hub_batteries = (
+        _BatteryState(
+            slave_id=0x33,
+            battery_voltage=50.4,
+            battery_remaining_capacity=44.493,
+            battery_capacity=49.995,
+            battery_percentage=89.0,
+        ),
+    )
+
+    entities = [
+        module.RenogyHubBatterySensor(coordinator, 0x33, description)
+        for description in module.HUB_BATTERY_SENSORS
+    ]
+    entities_by_key = {
+        entity.entity_description.key: entity
+        for entity in entities
+    }
+
+    assert entities_by_key["battery_voltage"].native_value == 50.4
+    assert entities_by_key["battery_remaining_capacity"].native_value == 44.493
+    assert entities_by_key["battery_capacity"].native_value == 49.995
+    assert entities_by_key["battery_percentage"].native_value == 89.0
+
+    voltage = entities_by_key["battery_voltage"]
+    assert voltage.available is True
+    assert voltage._attr_unique_id == "F0:F8:F2:57:47:0D:hub:33_battery_voltage"
+    assert voltage._attr_device_info["identifiers"] == {
+        ("renogy", "F0:F8:F2:57:47:0D:hub:33")
+    }
+    assert voltage._attr_device_info["via_device"] == (
+        "renogy",
+        "F0:F8:F2:57:47:0D",
+    )
+    assert voltage._attr_device_info["name"] == "Renogy Hub Battery 0x33"
+    assert voltage.extra_state_attributes == {"slave_id": "0x33"}
+
+
+def test_hub_battery_sensor_tracks_logical_battery_availability() -> None:
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.hub_batteries = (
+        _BatteryState(
+            slave_id=0x33,
+            battery_voltage=50.4,
+            available=False,
+        ),
+    )
+    entity = module.RenogyHubBatterySensor(
+        coordinator,
+        0x33,
+        module.HUB_BATTERY_SENSORS[0],
+    )
+
+    assert entity.available is False
+
+    coordinator.hub_batteries = (
+        _BatteryState(
+            slave_id=0x33,
+            battery_voltage=50.5,
+            available=True,
+        ),
+    )
+    assert entity.available is True
+    assert entity.native_value == 50.5
+
+    coordinator.last_update_success = False
+    assert entity.available is False
+
+
+def test_hub_sensor_setup_is_disabled_for_normal_coordinator() -> None:
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.communication_hub_enabled = False
+    config_entry = _ConfigEntry()
+    async_add_entities = MagicMock()
+
+    module.setup_hub_battery_sensors(
+        config_entry,
+        coordinator,
+        async_add_entities,
+    )
+
+    assert coordinator.listeners == []
+    assert config_entry.unload_callbacks == []
+    async_add_entities.assert_not_called()

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -184,10 +184,15 @@ def _load_hub_sensor_module() -> Any:
 
     module = importlib.import_module("custom_components.renogy.hub_sensor")
 
-    # Hub-specific imports are scoped to these focused tests. Remove them after
-    # import so unrelated platform tests load the production modules afresh.
+    # Hub-specific imports and the synthetic integration package are scoped to
+    # these focused tests. Remove them after import so unrelated platform tests
+    # load the production package and constants afresh.
     sys.modules.pop("custom_components.renogy.hub", None)
     sys.modules.pop("custom_components.renogy.const", None)
+    sys.modules.pop("custom_components.renogy", None)
+    custom_components_pkg = sys.modules.get("custom_components")
+    if custom_components_pkg is not None:
+        custom_components_pkg.__dict__.pop("renogy", None)
 
     return module
 

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -164,10 +164,10 @@ def _install_module_stubs() -> None:
     renogy_pkg.__path__ = [renogy_path]
     sys.modules["custom_components.renogy"] = renogy_pkg
 
-    const_stub = cast(Any, types.ModuleType("custom_components.renogy.const"))
-    const_stub.ATTR_MANUFACTURER = "Renogy"
-    const_stub.DOMAIN = "renogy"
-    sys.modules["custom_components.renogy.const"] = const_stub
+    # hub_sensor.py can safely use the real integration constants.
+    # Do not leave a synthetic custom_components.renogy.const module behind,
+    # because later tests import the actual integration package.
+    sys.modules.pop("custom_components.renogy.const", None)
 
     hub_stub = cast(Any, types.ModuleType("custom_components.renogy.hub"))
     hub_stub.RenogyHubBatteryState = _BatteryState
@@ -178,9 +178,17 @@ def _install_module_stubs() -> None:
 
 
 def _load_hub_sensor_module() -> Any:
+    """Load the Hub sensor module without leaking test stubs to later tests."""
     _install_module_stubs()
     sys.modules.pop("custom_components.renogy.hub_sensor", None)
-    return importlib.import_module("custom_components.renogy.hub_sensor")
+
+    module = importlib.import_module("custom_components.renogy.hub_sensor")
+
+    # The Hub model is stubbed only for these focused unit tests.
+    # Remove it after import so unrelated tests see the production module.
+    sys.modules.pop("custom_components.renogy.hub", None)
+
+    return module
 
 
 def test_hub_sensor_descriptions_expose_only_validated_telemetry() -> None:

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -7,6 +7,7 @@ import sys
 import types
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -26,6 +27,7 @@ class _Coordinator:
         self.address = "F0:F8:F2:57:47:0D"
         self.communication_hub_enabled = True
         self.last_update_success = True
+        self.device = SimpleNamespace(is_available=True)
         self.hub_batteries: tuple[_BatteryState, ...] = ()
         self.listeners: list[Any] = []
 
@@ -315,6 +317,9 @@ def test_hub_battery_sensor_tracks_logical_battery_availability() -> None:
     assert entity.native_value == 50.5
 
     coordinator.last_update_success = False
+    assert entity.available is True
+
+    coordinator.device.is_available = False
     assert entity.available is False
 
 

--- a/tests/test_hub_setup.py
+++ b/tests/test_hub_setup.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 from tests.test_init import _install_module_stubs
 
 
-def _load_init_module_with_hub_stub() -> tuple[Any, type, type]:
+def _load_init_module_with_hub_stub() -> tuple[Any, Any, Any]:
     """Load the integration with base and Hub coordinator stubs."""
     base_coordinator_class = _install_module_stubs()
     assert base_coordinator_class is not None

--- a/tests/test_hub_setup.py
+++ b/tests/test_hub_setup.py
@@ -1,0 +1,135 @@
+"""Tests for Communication Hub setup wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from tests.test_init import _install_module_stubs
+
+
+def _load_init_module_with_hub_stub() -> tuple[Any, type, type]:
+    """Load the integration with base and Hub coordinator stubs."""
+    base_coordinator_class = _install_module_stubs()
+    assert base_coordinator_class is not None
+
+    hub_module = cast(Any, types.ModuleType("custom_components.renogy.hub_coordinator"))
+
+    class RenogyHubBluetoothCoordinator:
+        """Stub Hub coordinator that records initialization arguments."""
+
+        last_init: dict[str, Any] | None = None
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            type(self).last_init = kwargs
+
+        def async_start(self):
+            """Return an unload callback."""
+            return lambda: None
+
+        async def async_request_refresh(self) -> None:
+            """Allow setup to schedule an initial refresh."""
+
+        def async_stop(self) -> None:
+            """Support unload behavior."""
+
+        async def async_shutdown(self) -> None:
+            """Support shutdown behavior."""
+
+    hub_module.RenogyHubBluetoothCoordinator = RenogyHubBluetoothCoordinator
+    sys.modules["custom_components.renogy.hub_coordinator"] = hub_module
+
+    sys.modules.pop("custom_components.renogy.__init__", None)
+    sys.modules.pop("custom_components.renogy", None)
+    module = importlib.import_module("custom_components.renogy")
+    return module, base_coordinator_class, RenogyHubBluetoothCoordinator
+
+
+def _entry(module: Any, *, device_type: str, hub_enabled: bool) -> MagicMock:
+    """Build a config-entry stub for Hub setup tests."""
+    entry = MagicMock()
+    entry.entry_id = "entry-hub"
+    entry.data = {
+        "address": "F0:F8:F2:57:47:0D",
+        module.CONF_DEVICE_TYPE: device_type,
+        module.CONF_SCAN_INTERVAL: 60,
+    }
+    entry.options = {
+        module.CONF_COMMUNICATION_HUB_ENABLED: hub_enabled,
+    }
+    entry.add_update_listener = MagicMock(return_value=lambda: None)
+    entry.async_on_unload = MagicMock()
+    return entry
+
+
+def test_communication_hub_defaults_to_disabled() -> None:
+    """Existing non-shunt entries must keep Hub polling disabled by default."""
+    module, _base, _hub = _load_init_module_with_hub_stub()
+    entry = MagicMock()
+    entry.data = {module.CONF_DEVICE_TYPE: module.DeviceType.INVERTER.value}
+    entry.options = {}
+
+    assert module._get_communication_hub_enabled(entry) is False
+
+
+def test_communication_hub_option_is_ignored_for_shunt() -> None:
+    """Smart Shunt entries must never enable Communication Hub polling."""
+    module, _base, _hub = _load_init_module_with_hub_stub()
+    entry = MagicMock()
+    entry.data = {module.CONF_DEVICE_TYPE: module.DeviceType.SHUNT300.value}
+    entry.options = {module.CONF_COMMUNICATION_HUB_ENABLED: True}
+
+    assert module._get_communication_hub_enabled(entry) is False
+
+
+def test_communication_hub_option_enables_hub_coordinator() -> None:
+    """An enabled non-shunt entry should use the Hub-aware coordinator."""
+    module, base_class, hub_class = _load_init_module_with_hub_stub()
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.async_create_task = lambda coro: asyncio.get_running_loop().create_task(coro)
+    entry = _entry(
+        module,
+        device_type=module.DeviceType.INVERTER.value,
+        hub_enabled=True,
+    )
+
+    result = asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert hub_class.last_init is not None
+    assert hub_class.last_init["communication_hub_enabled"] is True
+    assert base_class.last_init is None
+    assert isinstance(
+        hass.data[module.DOMAIN][entry.entry_id]["coordinator"],
+        hub_class,
+    )
+
+
+def test_disabled_hub_keeps_existing_base_coordinator() -> None:
+    """A disabled Hub option should preserve the existing coordinator path."""
+    module, base_class, hub_class = _load_init_module_with_hub_stub()
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.async_create_task = lambda coro: asyncio.get_running_loop().create_task(coro)
+    entry = _entry(
+        module,
+        device_type=module.DeviceType.INVERTER.value,
+        hub_enabled=False,
+    )
+
+    result = asyncio.run(module.async_setup_entry(hass, entry))
+
+    assert result is True
+    assert base_class.last_init is not None
+    assert hub_class.last_init is None
+    assert isinstance(
+        hass.data[module.DOMAIN][entry.entry_id]["coordinator"],
+        base_class,
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 def _install_module_stubs(*, install_ble: bool = True) -> type | None:
     """Install minimal module stubs to import the integration module."""
+    # Any focused test may have loaded integration constants through a synthetic
+    # custom_components.renogy package. Always force the production const module
+    # to be imported afresh before loading the real integration package.
+    sys.modules.pop("custom_components.renogy.const", None)
+
     homeassistant_module = cast(Any, types.ModuleType("homeassistant"))
     sys.modules["homeassistant"] = homeassistant_module
 

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -251,6 +251,7 @@ def _load_sensor_module() -> Any:
     """Load the sensor module with stubs in place."""
     _install_module_stubs()
     sys.modules.pop("custom_components.renogy.sensor", None)
+    sys.modules.pop("custom_components.renogy.const", None)
     sys.modules.pop("custom_components.renogy", None)
     return importlib.import_module("custom_components.renogy.sensor")
 
@@ -736,3 +737,52 @@ def test_battery_sensor_mapping_uses_library_field_names() -> None:
             _read_sensor_value(sensor_module, descriptions[key], sample_data)
             == expected
         )
+
+
+def test_sensor_setup_registers_hub_battery_sensor_layer() -> None:
+    """Ensure the sensor platform activates the logical Hub battery layer."""
+    sensor_module = _load_sensor_module()
+
+    coordinator = MagicMock()
+    coordinator.device = None
+    coordinator.address = "F0:F8:F2:57:47:0D"
+
+    hass = MagicMock()
+    hass.data = {
+        sensor_module.DOMAIN: {
+            "entry-1": {
+                "coordinator": coordinator,
+            }
+        }
+    }
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.data = {
+        sensor_module.CONF_DEVICE_TYPE: sensor_module.DeviceType.INVERTER.value
+    }
+
+    async_add_entities = MagicMock()
+
+    with patch.object(
+        sensor_module,
+        "create_entities_helper",
+        return_value=[],
+    ):
+        with patch.object(
+            sensor_module,
+            "setup_hub_battery_sensors",
+        ) as setup_hub:
+            asyncio.run(
+                sensor_module.async_setup_entry(
+                    hass,
+                    config_entry,
+                    async_add_entities,
+                )
+            )
+
+    setup_hub.assert_called_once_with(
+        config_entry,
+        coordinator,
+        async_add_entities,
+    )


### PR DESCRIPTION
## Summary

Add opt-in Renogy Communication Hub support for multiple batteries behind a single BT-2 connection while preserving existing parent-device behavior.

## Behavior

- discover responding Hub battery Modbus slave IDs dynamically in the bounded `0x30`-`0x37` range
- create one logical Home Assistant child device per responding battery
- expose exactly four validated read-only sensors per Hub battery:
  - Voltage
  - Remaining Capacity
  - Nominal Capacity
  - State of Charge
- keep `0x30` as the legacy/primary battery source when present
- reuse the existing BT-2 BLE session for parent and Hub polling
- isolate Hub polling failures from parent inverter availability
- preserve Hub child identity across reloads and rediscovery
- support rediscovery so batteries that appear later can be added without duplicate entities
- keep the feature opt-in for non-shunt devices

## Dependency

This integration now targets the official `renogy-ble==2.5.0` release, which contains the corresponding Communication Hub reader from `renogy-ble` PR #148. The dependency update itself is already present on upstream `main` via renogy-ha PR #207, so this PR contains only the Home Assistant integration and test changes.

## Hardware validation

Validated on real BT-2 / Communication Hub hardware with four responding batteries at:

- `0x30`
- `0x31`
- `0x32`
- `0x33`

Observed behavior:

- exactly four Hub child devices were created
- each child exposed the intended four sensors
- no phantom `0x34`-`0x37` devices were created
- voltage, remaining capacity, nominal capacity, and state of charge matched live telemetry
- reloads preserved device identity without duplicate entities
- battery disappearance/recovery remained isolated from the parent inverter
- parent inverter telemetry remained functional while Hub polling shared the BT-2 session

## Validation

Normal locked environment:

- `uv lock --check`
- verified `renogy-ble` resolves to `2.5.0`
- `uv run --locked ruff format --check .`
- `uv run --locked ruff check . --output-format=github`
- `uv run --locked ty check . --output-format=github`
- `uv run --locked pytest tests` - 111 passed
- `git diff --check`

Minimum supported Home Assistant resolution, matching upstream CI:

- resolved Home Assistant `2026.3.0`
- resolved `renogy-ble 2.5.0`
- `uv run --locked --resolution lowest-direct pytest tests` - 111 passed
- lowest-direct Ruff and ty checks passed

The branch is synchronized with current upstream `main` and the final diff is limited to the 17 Communication Hub integration/test files.