### PR TITLE
feat: expose Communication Hub battery current and power

### DIFF
--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -16,6 +16,8 @@ class RenogyHubBatteryState:
 
     slave_id: int
     battery_voltage: float | None
+    battery_current: float | None
+    battery_power: float | None
     battery_remaining_capacity: float | None
     battery_capacity: float | None
     battery_percentage: float | None
@@ -26,6 +28,8 @@ class RenogyHubBatteryState:
         return {
             "slave_id": self.slave_id,
             "battery_voltage": self.battery_voltage,
+            "battery_current": self.battery_current,
+            "battery_power": self.battery_power,
             "battery_remaining_capacity": self.battery_remaining_capacity,
             "battery_capacity": self.battery_capacity,
             "battery_percentage": self.battery_percentage,
@@ -97,6 +101,8 @@ class RenogyHubBatteryManager:
         return RenogyHubBatteryState(
             slave_id=int(battery.slave_id),
             battery_voltage=_optional_float(data.get("battery_voltage")),
+            battery_current=_optional_float(data.get("battery_current")),
+            battery_power=_optional_float(data.get("battery_power")),
             battery_remaining_capacity=_optional_float(
                 data.get("battery_remaining_capacity")
             ),

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -14,7 +14,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfElectricPotential
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfPower,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -30,6 +35,22 @@ HUB_BATTERY_SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_current",
+        name="Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    SensorEntityDescription(
+        key="battery_power",
+        name="Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
     ),
     SensorEntityDescription(
         key="battery_remaining_capacity",

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -70,8 +70,8 @@ def _manager(results: list[_FakeResult]) -> tuple[Any, _FakeHub]:
     return manager, fake_hub
 
 
-def test_hub_manager_caches_only_validated_fields() -> None:
-    """Unvalidated current and power values must not enter HA Hub state."""
+def test_hub_manager_caches_validated_fields() -> None:
+    """Validated Hub telemetry should enter Home Assistant state."""
     manager, _hub = _manager(
         [
             _FakeResult(
@@ -83,8 +83,8 @@ def test_hub_manager_caches_only_validated_fields() -> None:
                         battery_remaining_capacity=42.389,
                         battery_capacity=49.995,
                         battery_percentage=84.8,
-                        battery_current=123.45,
-                        battery_power=6789,
+                        battery_current=3.26,
+                        battery_power=162.348,
                     )
                 ],
             )
@@ -99,12 +99,12 @@ def test_hub_manager_caches_only_validated_fields() -> None:
     assert battery.as_dict() == {
         "slave_id": 0x30,
         "battery_voltage": 49.8,
+        "battery_current": 3.26,
+        "battery_power": 162.348,
         "battery_remaining_capacity": 42.389,
         "battery_capacity": 49.995,
         "battery_percentage": 84.8,
     }
-    assert "battery_current" not in battery.as_dict()
-    assert "battery_power" not in battery.as_dict()
 
 
 def test_hub_manager_marks_missing_cached_battery_unavailable() -> None:

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock
 class _BatteryState:
     slave_id: int
     battery_voltage: float | None = None
+    battery_current: float | None = None
+    battery_power: float | None = None
     battery_remaining_capacity: float | None = None
     battery_capacity: float | None = None
     battery_percentage: float | None = None
@@ -94,6 +96,8 @@ def _install_module_stubs() -> None:
 
     class SensorDeviceClass:
         VOLTAGE = "voltage"
+        CURRENT = "current"
+        POWER = "power"
         BATTERY = "battery"
 
     class SensorStateClass:
@@ -116,10 +120,18 @@ def _install_module_stubs() -> None:
     const_module = cast(Any, types.ModuleType("homeassistant.const"))
     const_module.PERCENTAGE = "%"
 
+    class UnitOfElectricCurrent:
+        AMPERE = "A"
+
     class UnitOfElectricPotential:
         VOLT = "V"
 
+    class UnitOfPower:
+        WATT = "W"
+
+    const_module.UnitOfElectricCurrent = UnitOfElectricCurrent
     const_module.UnitOfElectricPotential = UnitOfElectricPotential
+    const_module.UnitOfPower = UnitOfPower
     sys.modules["homeassistant.const"] = const_module
 
     core_module = cast(Any, types.ModuleType("homeassistant.core"))
@@ -204,6 +216,8 @@ def test_hub_sensor_descriptions_expose_only_validated_telemetry() -> None:
 
     assert {description.key for description in module.HUB_BATTERY_SENSORS} == {
         "battery_voltage",
+        "battery_current",
+        "battery_power",
         "battery_remaining_capacity",
         "battery_capacity",
         "battery_percentage",
@@ -233,7 +247,7 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
     coordinator.notify()
 
     assert len(added_batches) == 1
-    assert len(added_batches[0]) == 8
+    assert len(added_batches[0]) == 12
     assert {entity._slave_id for entity in added_batches[0]} == {0x30, 0x33}
 
     coordinator.notify()
@@ -246,7 +260,7 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
     coordinator.notify()
 
     assert len(added_batches) == 2
-    assert len(added_batches[1]) == 4
+    assert len(added_batches[1]) == 6
     assert {entity._slave_id for entity in added_batches[1]} == {0x31}
 
 
@@ -257,6 +271,8 @@ def test_hub_battery_0x33_is_child_device_with_validated_values() -> None:
         _BatteryState(
             slave_id=0x33,
             battery_voltage=50.4,
+            battery_current=3.26,
+            battery_power=164.304,
             battery_remaining_capacity=44.493,
             battery_capacity=49.995,
             battery_percentage=89.0,
@@ -270,6 +286,8 @@ def test_hub_battery_0x33_is_child_device_with_validated_values() -> None:
     entities_by_key = {entity.entity_description.key: entity for entity in entities}
 
     assert entities_by_key["battery_voltage"].native_value == 50.4
+    assert entities_by_key["battery_current"].native_value == 3.26
+    assert entities_by_key["battery_power"].native_value == 164.304
     assert entities_by_key["battery_remaining_capacity"].native_value == 44.493
     assert entities_by_key["battery_capacity"].native_value == 49.995
     assert entities_by_key["battery_percentage"].native_value == 89.0


### PR DESCRIPTION
## Summary

Expose Current and Power sensors for logical batteries connected through a Renogy Communication Hub.

`renogy-ha` already depends on `renogy-ble==2.6.0`, which provides validated `battery_current` and `battery_power` values from the Hub's existing battery pack-status response. This change carries those fields into the Home Assistant Hub battery state and exposes them as standard Current and Power sensor entities.

## Changes

- add `battery_current` and `battery_power` to `RenogyHubBatteryState`
- copy the two fields from `renogy-ble` Hub battery parsed data
- add Current (`A`) and Power (`W`) sensor entities for each discovered Hub battery
- preserve existing logical battery device identity and availability behavior
- update focused Hub state and sensor tests for six entities per battery

## Transport impact

No additional BLE or Modbus requests are introduced by this change. Current and Power are supplied by `renogy-ble 2.6.0` from the existing Hub battery pack-status read.

## Validation

- 152 tests passed
- Ruff lint passed
- `ty` type check passed
- Ruff format check passed
- `git diff --check` passed
