### PR TITLE
Add RIV4835CSH1S inverter profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ The integration is configurable through the Home Assistant UI after installation
   - Smart Shunt 300 devices support `sustained` and `intermittent`
   - Batteries, controllers, DCC chargers, and inverters support `intermittent` and `persistent_session`
   - See [docs/connection-modes.md](docs/connection-modes.md) for behavior and recommendations
+- **Inverter Profile**: Inverter entries can use the generic register layout or
+  the model-specific `RIV4835CSH1S` profile
+  - Existing entries can switch profiles through **Reconfigure** without being deleted
+  - See [docs/inverter-profiles.md](docs/inverter-profiles.md) for selection guidance
 
 ## Sensors
 

--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.device_registry import async_get as async_get_device_
 from .const import (
     CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_TYPE,
+    CONF_INVERTER_PROFILE,
     CONF_MAX_FAILURES,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SCAN_INTERVAL,
@@ -20,6 +21,7 @@ from .const import (
     CONF_UNAVAILABLE_RETRY_INTERVAL,
     DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_INVERTER_PROFILE,
     DEFAULT_MAX_FAILURES,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -27,6 +29,7 @@ from .const import (
     DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
     DOMAIN,
     LOGGER,
+    RIV4835CSH1S_INVERTER_PROFILE,
     DeviceType,
 )
 from .device_name import has_real_device_name
@@ -63,6 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     shunt_connection_mode = _get_shunt_connection_mode(entry)
     non_shunt_connection_mode = _get_non_shunt_connection_mode(entry)
     communication_hub_enabled = _get_communication_hub_enabled(entry)
+    model_hint = _get_inverter_model_hint(entry)
 
     if not device_address:
         LOGGER.error("No device address provided in config entry")
@@ -98,6 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             unavailable_retry_interval=unavailable_retry_interval,
             device_data_callback=device_data_callback,
             communication_hub_enabled=True,
+            model_hint=model_hint,
         )
     else:
         coordinator = RenogyActiveBluetoothCoordinator(
@@ -111,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             max_failures=max_failures,
             unavailable_retry_interval=unavailable_retry_interval,
             device_data_callback=device_data_callback,
+            model_hint=model_hint,
         )
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
@@ -183,6 +189,20 @@ def _get_communication_hub_enabled(entry: ConfigEntry) -> bool:
             DEFAULT_COMMUNICATION_HUB_ENABLED,
         )
     )
+
+
+def _get_inverter_model_hint(entry: ConfigEntry) -> str | None:
+    """Return a model hint only for a configured model-specific inverter profile."""
+    if (
+        entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+        != DeviceType.INVERTER.value
+    ):
+        return None
+
+    profile = entry.data.get(CONF_INVERTER_PROFILE, DEFAULT_INVERTER_PROFILE)
+    if profile == RIV4835CSH1S_INVERTER_PROFILE:
+        return RIV4835CSH1S_INVERTER_PROFILE
+    return None
 
 
 async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -115,6 +115,7 @@ class RenogyActiveBluetoothCoordinator(
         non_shunt_connection_mode: str = DEFAULT_NON_SHUNT_CONNECTION_MODE,
         max_failures: int = DEFAULT_MAX_FAILURES,
         unavailable_retry_interval: int = DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
+        model_hint: str | None = None,
         device_data_callback: Callable[[RenogyBLEDevice], Awaitable[None]]
         | None = None,
     ):
@@ -135,6 +136,7 @@ class RenogyActiveBluetoothCoordinator(
         self.max_failures = max_failures
         self.unavailable_retry_interval = unavailable_retry_interval
         self.device_type = device_type
+        self.model_hint = model_hint
         self.last_poll_time: datetime | None = None
         self.device_data_callback = device_data_callback
         self.logger.debug(
@@ -462,6 +464,7 @@ class RenogyActiveBluetoothCoordinator(
                 manufacturer_data=manufacturer_data,
                 max_failures=self.max_failures,
                 unavailable_retry_interval=self.unavailable_retry_interval,
+                model_hint=self.model_hint,
             )
         else:
             old_name = self.device.name
@@ -491,6 +494,9 @@ class RenogyActiveBluetoothCoordinator(
                     self.device_type,
                 )
                 self.device.device_type = self.device_type
+
+            # Service-info refreshes must not drop the configured register profile.
+            self.device.model_hint = self.model_hint
 
         if (
             self._uses_intermittent_shunt_reads(self.device.device_type)

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -21,12 +21,14 @@ from .const import (
     CONF_COMMUNICATION_HUB_ENABLED,
     CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
+    CONF_INVERTER_PROFILE,
     CONF_MAX_FAILURES,
     CONF_NON_SHUNT_CONNECTION_MODE,
     CONF_SHUNT_CONNECTION_MODE,
     CONF_UNAVAILABLE_RETRY_INTERVAL,
     DEFAULT_COMMUNICATION_HUB_ENABLED,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_INVERTER_PROFILE,
     DEFAULT_MAX_FAILURES,
     DEFAULT_NON_SHUNT_CONNECTION_MODE,
     DEFAULT_SCAN_INTERVAL,
@@ -34,6 +36,7 @@ from .const import (
     DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
     DEVICE_TYPES,
     DOMAIN,
+    INVERTER_PROFILES,
     LOGGER,
     MAX_MAX_FAILURES,
     MAX_SCAN_INTERVAL,
@@ -181,6 +184,9 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
         self._discovered_device: BluetoothServiceInfoBleak | None = None
         self._default_device_type: str = DEFAULT_DEVICE_TYPE
+        self._pending_entry_data: dict[str, Any] | None = None
+        self._pending_entry_title: str | None = None
+        self._pending_reconfigure_data: dict[str, Any] | None = None
 
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> RenogyOptionsFlowHandler:
@@ -257,10 +263,8 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._discovered_device
                 )
 
-                # Create a config entry
-                return self.async_create_entry(
-                    title=_display_name_for_discovery(self._discovered_device),
-                    data=user_input,
+                return await self._async_finish_user_step(
+                    _display_name_for_discovery(self._discovered_device), user_input
                 )
             elif CONF_ADDRESS in user_input:
                 # Manual device selection
@@ -280,9 +284,8 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(address, raise_on_progress=False)
                 self._abort_if_unique_id_configured()
 
-                return self.async_create_entry(
-                    title=_display_name_for_discovery(discovery_info),
-                    data=user_input,
+                return await self._async_finish_user_step(
+                    _display_name_for_discovery(discovery_info), user_input
                 )
 
         # If we have a discovered device from bluetooth auto-discovery,
@@ -336,6 +339,43 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def _async_finish_user_step(
+        self, title: str, data: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Create a non-inverter entry or request its inverter profile."""
+        if data[CONF_DEVICE_TYPE] != DeviceType.INVERTER.value:
+            data.pop(CONF_INVERTER_PROFILE, None)
+            return self.async_create_entry(title=title, data=data)
+
+        self._pending_entry_title = title
+        self._pending_entry_data = data
+        return await self.async_step_inverter_profile()
+
+    async def async_step_inverter_profile(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select the register profile for a new inverter entry."""
+        if self._pending_entry_data is None or self._pending_entry_title is None:
+            return self.async_abort(reason="inverter_profile_missing_context")
+
+        if user_input is not None:
+            data = {
+                **self._pending_entry_data,
+                CONF_INVERTER_PROFILE: user_input[CONF_INVERTER_PROFILE],
+            }
+            return self.async_create_entry(title=self._pending_entry_title, data=data)
+
+        return self.async_show_form(
+            step_id="inverter_profile",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_INVERTER_PROFILE, default=DEFAULT_INVERTER_PROFILE
+                    ): vol.In(INVERTER_PROFILES)
+                }
+            ),
+        )
+
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -357,12 +397,17 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
             scan_interval = user_input[CONF_SCAN_INTERVAL]
+            updates = {
+                CONF_DEVICE_TYPE: device_type,
+                CONF_SCAN_INTERVAL: scan_interval,
+            }
+            if device_type == DeviceType.INVERTER.value:
+                self._pending_reconfigure_data = updates
+                return await self.async_step_reconfigure_inverter_profile()
+
             return self.async_update_reload_and_abort(
                 entry,
-                data_updates={
-                    CONF_DEVICE_TYPE: device_type,
-                    CONF_SCAN_INTERVAL: scan_interval,
-                },
+                data_updates=updates,
                 options={**entry.options, CONF_SCAN_INTERVAL: scan_interval},
             )
 
@@ -393,6 +438,41 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
                 "device_name": entry.title,
                 "current_device_type": current_type,
             },
+        )
+
+    async def async_step_reconfigure_inverter_profile(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select and persist the profile while reconfiguring an inverter."""
+        entry = self._get_reconfigure_entry()
+        if self._pending_reconfigure_data is None:
+            return self.async_abort(reason="inverter_profile_missing_context")
+
+        current_profile = entry.data.get(
+            CONF_INVERTER_PROFILE, DEFAULT_INVERTER_PROFILE
+        )
+        if user_input is not None:
+            updates = {
+                **self._pending_reconfigure_data,
+                CONF_INVERTER_PROFILE: user_input[CONF_INVERTER_PROFILE],
+            }
+            scan_interval = updates[CONF_SCAN_INTERVAL]
+            return self.async_update_reload_and_abort(
+                entry,
+                data_updates=updates,
+                options={**entry.options, CONF_SCAN_INTERVAL: scan_interval},
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_inverter_profile",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_INVERTER_PROFILE, default=current_profile
+                    ): vol.In(INVERTER_PROFILES)
+                }
+            ),
+            description_placeholders={"device_name": entry.title},
         )
 
     def _detect_device_type_from_coordinator(self, entry: ConfigEntry) -> str | None:

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -35,6 +35,7 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_MAX_FAILURES = "max_failures"
 CONF_UNAVAILABLE_RETRY_INTERVAL = "unavailable_retry_interval"
 CONF_DEVICE_TYPE = "device_type"  # New constant for device type
+CONF_INVERTER_PROFILE = "inverter_profile"
 CONF_DEVICE_NAME = "device_name"
 CONF_SHUNT_CONNECTION_MODE = "shunt_connection_mode"
 CONF_NON_SHUNT_CONNECTION_MODE = "non_shunt_connection_mode"
@@ -57,6 +58,11 @@ class DeviceType(Enum):
 # List of supported device types
 DEVICE_TYPES = [e.value for e in DeviceType]
 DEFAULT_DEVICE_TYPE = DeviceType.CONTROLLER.value
+
+GENERIC_INVERTER_PROFILE = "generic"
+RIV4835CSH1S_INVERTER_PROFILE = "RIV4835CSH1S"
+INVERTER_PROFILES = [GENERIC_INVERTER_PROFILE, RIV4835CSH1S_INVERTER_PROFILE]
+DEFAULT_INVERTER_PROFILE = GENERIC_INVERTER_PROFILE
 
 
 class ShuntConnectionMode(Enum):

--- a/custom_components/renogy/sensor.py
+++ b/custom_components/renogy/sensor.py
@@ -35,9 +35,12 @@ from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
 from .const import (
     ATTR_MANUFACTURER,
     CONF_DEVICE_TYPE,
+    CONF_INVERTER_PROFILE,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_INVERTER_PROFILE,
     DOMAIN,
     LOGGER,
+    RIV4835CSH1S_INVERTER_PROFILE,
     DeviceType,
 )
 from .hub_sensor import setup_hub_battery_sensors
@@ -138,6 +141,7 @@ KEY_AC_INPUT_VOLTAGE = "ac_input_voltage"
 KEY_AC_INPUT_CURRENT = "ac_input_current"
 KEY_CHARGING_CURRENT = "charging_current"
 KEY_CHARGING_POWER = "charging_power"
+KEY_LINE_CHARGING_CURRENT = "line_charging_current"
 
 
 @dataclass(frozen=True)
@@ -854,6 +858,17 @@ INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
     ),
 )
 
+RIV4835CSH1S_INVERTER_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
+    RenogyBLESensorDescription(
+        key=KEY_LINE_CHARGING_CURRENT,
+        name="Line Charging Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+)
+
 RENOGY_BATTERY_SENSORS: tuple[RenogyBLESensorDescription, ...] = (
     RenogyBLESensorDescription(
         key=KEY_BATTERY_VOLTAGE,
@@ -1006,6 +1021,9 @@ async def async_setup_entry(
 
     # Get device type from config
     device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+    inverter_profile = config_entry.data.get(
+        CONF_INVERTER_PROFILE, DEFAULT_INVERTER_PROFILE
+    )
     LOGGER.debug("Setting up sensors for device type: %s", device_type)
 
     # Create entities with the best name currently available.
@@ -1019,7 +1037,9 @@ async def async_setup_entry(
         LOGGER.info("Creating entities with coordinator only (generic name)")
         device = None
 
-    device_entities = create_entities_helper(coordinator, device, device_type)
+    device_entities = create_entities_helper(
+        coordinator, device, device_type, inverter_profile
+    )
 
     # Add all entities to Home Assistant
     if device_entities:
@@ -1041,6 +1061,7 @@ def create_entities_helper(
     coordinator: RenogyActiveBluetoothCoordinator,
     device: Optional[RenogyBLEDevice],
     device_type: str = DEFAULT_DEVICE_TYPE,
+    inverter_profile: str = DEFAULT_INVERTER_PROFILE,
 ) -> List[RenogyBLESensor]:
     """Create sensor entities with provided coordinator and optional device."""
     entities = []
@@ -1050,6 +1071,14 @@ def create_entities_helper(
         device_type,
         SENSORS_BY_DEVICE_TYPE[DeviceType.CONTROLLER.value],
     )
+    if (
+        device_type == DeviceType.INVERTER.value
+        and inverter_profile == RIV4835CSH1S_INVERTER_PROFILE
+    ):
+        sensor_groups = {
+            **sensor_groups,
+            "RIV4835CSH1S": RIV4835CSH1S_INVERTER_SENSORS,
+        }
 
     # Group sensors by category
     for category_name, sensor_list in sensor_groups.items():

--- a/custom_components/renogy/strings.json
+++ b/custom_components/renogy/strings.json
@@ -15,6 +15,18 @@
           "scan_interval": "Polling interval (seconds)",
           "device_type": "Device Type"
         }
+      },
+      "inverter_profile": {
+        "description": "Select the register profile for this inverter. Use Generic unless the inverter model is RIV4835CSH1S.",
+        "data": {
+          "inverter_profile": "Inverter profile"
+        }
+      },
+      "reconfigure_inverter_profile": {
+        "description": "Select the register profile for Renogy BLE device: {device_name}.",
+        "data": {
+          "inverter_profile": "Inverter profile"
+        }
       }
     },
     "error": {
@@ -25,7 +37,8 @@
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
       "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time.",
-      "reconfigure_successful": "Re-configuration was successful"
+      "reconfigure_successful": "Re-configuration was successful",
+      "inverter_profile_missing_context": "The inverter profile step expired. Start setup or reconfiguration again."
     }
   },
   "options": {

--- a/custom_components/renogy/translations/en.json
+++ b/custom_components/renogy/translations/en.json
@@ -15,6 +15,18 @@
           "scan_interval": "Polling interval (seconds)",
           "device_type": "Device Type"
         }
+      },
+      "inverter_profile": {
+        "description": "Select the register profile for this inverter. Use Generic unless the inverter model is RIV4835CSH1S.",
+        "data": {
+          "inverter_profile": "Inverter profile"
+        }
+      },
+      "reconfigure_inverter_profile": {
+        "description": "Select the register profile for Renogy BLE device: {device_name}.",
+        "data": {
+          "inverter_profile": "Inverter profile"
+        }
       }
     },
     "error": {
@@ -25,7 +37,8 @@
       "no_devices_found": "No Renogy BLE devices discovered",
       "not_supported_device": "This device is not a supported Renogy BLE device",
       "unsupported_device_type": "The {device_type} device type is not currently supported. Only controller, battery, DCC (DC-DC charger), inverter, and shunt300 devices are fully supported at this time.",
-      "reconfigure_successful": "Re-configuration was successful"
+      "reconfigure_successful": "Re-configuration was successful",
+      "inverter_profile_missing_context": "The inverter profile step expired. Start setup or reconfiguration again."
     }
   },
   "options": {

--- a/docs/inverter-profiles.md
+++ b/docs/inverter-profiles.md
@@ -1,0 +1,17 @@
+# Inverter profiles
+
+Renogy inverters do not all use the same Modbus register layout. During setup,
+select the profile matching the inverter model:
+
+- **Generic** uses the standard inverter register sequence.
+- **RIV4835CSH1S** uses the model-specific register sequence supported by
+  `renogy-ble`.
+
+Existing inverter entries can switch profiles without being deleted. Open the
+Renogy integration entry, choose **Reconfigure**, keep the device type set to
+**Inverter**, continue, and select **RIV4835CSH1S**. The entry reloads with the
+new profile and exposes the model-specific line charging current telemetry.
+
+Do not select the RIV4835CSH1S profile for another inverter model. The profile
+controls which registers the integration requests; a mismatched profile may
+return incomplete or incorrect data.

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -139,6 +139,7 @@ def _install_module_stubs() -> None:
             manufacturer_data=None,
             max_failures=3,
             unavailable_retry_interval=10,
+            model_hint=None,
         ):
             self.ble_device = ble_device
             self.address = ble_device.address
@@ -148,6 +149,7 @@ def _install_module_stubs() -> None:
             self.manufacturer_data = manufacturer_data or {}
             self.max_failures = max_failures
             self.unavailable_retry_interval = unavailable_retry_interval
+            self.model_hint = model_hint
             self.parsed_data = {}
             self.failure_count = 0
             self.is_available = True
@@ -577,6 +579,33 @@ def test_inverter_client_uses_inverter_modbus_device_id() -> None:
     )
 
     assert coordinator._ble_client.device_id == 0x20
+
+
+def test_inverter_model_hint_is_applied_and_preserved_on_refresh() -> None:
+    """The configured inverter profile must survive service-info refreshes."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="inverter",
+        model_hint="RIV4835CSH1S",
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="RNGRIU123456",
+        rssi=-60,
+    )
+
+    device = coordinator._update_device_from_service_info(service_info)
+    assert device.model_hint == "RIV4835CSH1S"
+
+    device.model_hint = None
+    refreshed_device = coordinator._update_device_from_service_info(service_info)
+
+    assert refreshed_device is device
+    assert refreshed_device.model_hint == "RIV4835CSH1S"
 
 
 def test_non_shunt_persistent_mode_uses_library_persistent_transport():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -337,6 +337,49 @@ def test_manual_entry_keeps_explicit_device_type_override() -> None:
     }
 
 
+def test_inverter_setup_persists_selected_model_profile() -> None:
+    """Inverter setup should request and store the model-specific profile."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow = config_flow_module.RenogyConfigFlow()
+    flow._discovered_device = config_flow_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="RNGRIU123456",
+    )
+
+    profile_form = asyncio.run(
+        flow.async_step_user(
+            {
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.INVERTER.value,
+                const_module.CONF_SCAN_INTERVAL: 60,
+            }
+        )
+    )
+
+    assert profile_form["type"] == "form"
+    assert profile_form["step_id"] == "inverter_profile"
+    assert (
+        _schema_default(profile_form["data_schema"], const_module.CONF_INVERTER_PROFILE)
+        == const_module.DEFAULT_INVERTER_PROFILE
+    )
+
+    result = asyncio.run(
+        flow.async_step_inverter_profile(
+            {
+                const_module.CONF_INVERTER_PROFILE: (
+                    const_module.RIV4835CSH1S_INVERTER_PROFILE
+                )
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][const_module.CONF_INVERTER_PROFILE] == (
+        const_module.RIV4835CSH1S_INVERTER_PROFILE
+    )
+    assert result["data"]["address"] == "AA:BB:CC:DD:EE:FF"
+
+
 def _make_reconfigure_flow(
     config_flow_module: Any,
     const_module: Any,
@@ -514,6 +557,52 @@ def test_reconfigure_updates_scan_interval_already_saved_in_options() -> None:
         const_module.CONF_SCAN_INTERVAL: 120,
         const_module.CONF_MAX_FAILURES: 5,
     }
+
+
+def test_reconfigure_inverter_persists_selected_profile() -> None:
+    """Inverter reconfiguration should preserve and update its profile."""
+    config_flow_module = _load_config_flow_module()
+    const_module = importlib.import_module("custom_components.renogy.const")
+    flow, entry = _make_reconfigure_flow(
+        config_flow_module,
+        const_module,
+        data={
+            "address": "CC:45:A5:8A:8F:D4",
+            const_module.CONF_DEVICE_TYPE: const_module.DeviceType.INVERTER.value,
+            const_module.CONF_SCAN_INTERVAL: 60,
+            const_module.CONF_INVERTER_PROFILE: (
+                const_module.RIV4835CSH1S_INVERTER_PROFILE
+            ),
+        },
+    )
+
+    profile_form = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                const_module.CONF_DEVICE_TYPE: const_module.DeviceType.INVERTER.value,
+                const_module.CONF_SCAN_INTERVAL: 90,
+            }
+        )
+    )
+
+    assert profile_form["step_id"] == "reconfigure_inverter_profile"
+    assert (
+        _schema_default(profile_form["data_schema"], const_module.CONF_INVERTER_PROFILE)
+        == const_module.RIV4835CSH1S_INVERTER_PROFILE
+    )
+
+    result = asyncio.run(
+        flow.async_step_reconfigure_inverter_profile(
+            {const_module.CONF_INVERTER_PROFILE: const_module.DEFAULT_INVERTER_PROFILE}
+        )
+    )
+
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[const_module.CONF_INVERTER_PROFILE] == (
+        const_module.DEFAULT_INVERTER_PROFILE
+    )
+    assert entry.data[const_module.CONF_SCAN_INTERVAL] == 90
+    assert entry.options[const_module.CONF_SCAN_INTERVAL] == 90
 
 
 def test_reconfigure_rejects_unsupported_device_type() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -132,6 +132,50 @@ def test_non_shunt_connection_mode_defaults_to_intermittent() -> None:
     assert init_module._get_non_shunt_connection_mode(entry) == "intermittent"
 
 
+def test_inverter_model_hint_only_applies_to_model_specific_profile() -> None:
+    """Generic and non-inverter entries must not select a model profile."""
+    init_module, _ = _load_init_module()
+    entry = MagicMock()
+    entry.data = {
+        init_module.CONF_DEVICE_TYPE: init_module.DeviceType.INVERTER.value,
+        init_module.CONF_INVERTER_PROFILE: (init_module.RIV4835CSH1S_INVERTER_PROFILE),
+    }
+
+    assert init_module._get_inverter_model_hint(entry) == "RIV4835CSH1S"
+
+    entry.data[init_module.CONF_INVERTER_PROFILE] = init_module.DEFAULT_INVERTER_PROFILE
+    assert init_module._get_inverter_model_hint(entry) is None
+
+    entry.data[init_module.CONF_DEVICE_TYPE] = init_module.DeviceType.CONTROLLER.value
+    entry.data[init_module.CONF_INVERTER_PROFILE] = (
+        init_module.RIV4835CSH1S_INVERTER_PROFILE
+    )
+    assert init_module._get_inverter_model_hint(entry) is None
+
+
+def test_async_setup_entry_passes_selected_inverter_model_hint() -> None:
+    """Setup should pass the selected released profile into the coordinator."""
+    init_module, coordinator_class = _load_init_module()
+    hass = MagicMock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    hass.async_create_task = lambda coro: asyncio.get_running_loop().create_task(coro)
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {
+        "address": "AA:BB:CC:DD:EE:FF",
+        init_module.CONF_DEVICE_TYPE: init_module.DeviceType.INVERTER.value,
+        init_module.CONF_INVERTER_PROFILE: (init_module.RIV4835CSH1S_INVERTER_PROFILE),
+    }
+    entry.options = {}
+    entry.add_update_listener = MagicMock(return_value=lambda: None)
+    entry.async_on_unload = MagicMock()
+
+    assert asyncio.run(init_module.async_setup_entry(hass, entry)) is True
+    assert coordinator_class.last_init["model_hint"] == "RIV4835CSH1S"
+
+
 def test_async_setup_entry_uses_configured_shunt_connection_mode() -> None:
     """Ensure setup passes the selected shunt mode into the coordinator."""
     init_module, coordinator_class = _load_init_module()

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -328,7 +328,10 @@ def test_sensor_setup_does_not_wait_for_named_shunt() -> None:
 
     coordinator.async_request_refresh.assert_not_awaited()
     create.assert_called_once_with(
-        coordinator, device, sensor_module.DeviceType.SHUNT300.value
+        coordinator,
+        device,
+        sensor_module.DeviceType.SHUNT300.value,
+        sensor_module.DEFAULT_INVERTER_PROFILE,
     )
     async_add_entities.assert_not_called()
 
@@ -364,7 +367,10 @@ def test_sensor_setup_does_not_wait_for_unknown_device_name() -> None:
 
     coordinator.async_request_refresh.assert_not_awaited()
     create.assert_called_once_with(
-        coordinator, None, sensor_module.DeviceType.CONTROLLER.value
+        coordinator,
+        None,
+        sensor_module.DeviceType.CONTROLLER.value,
+        sensor_module.DEFAULT_INVERTER_PROFILE,
     )
     async_add_entities.assert_called_once_with(["entity"])
 
@@ -811,8 +817,8 @@ def test_sensor_setup_registers_hub_battery_sensor_layer() -> None:
     )
 
 
-def test_inverter_sensors_cover_rego_fields() -> None:
-    """Ensure REGO inverter fields are exposed via INVERTER_SENSORS."""
+def test_inverter_sensors_cover_profile_fields() -> None:
+    """Ensure common and RIV-only inverter fields have entity descriptions."""
     sensor_module = _load_sensor_module()
 
     keys = {description.key for description in sensor_module.INVERTER_SENSORS}
@@ -827,3 +833,33 @@ def test_inverter_sensors_cover_rego_fields() -> None:
         "charging_power",
         "charging_status",
     } <= keys
+    assert {
+        description.key for description in sensor_module.RIV4835CSH1S_INVERTER_SENSORS
+    } == {"line_charging_current"}
+
+
+def test_line_charging_current_only_created_for_riv_profile() -> None:
+    """Generic inverters should not gain an unavailable RIV-only entity."""
+    sensor_module = _load_sensor_module()
+    coordinator = MagicMock()
+    coordinator.address = "AA:BB:CC:DD:EE:FF"
+
+    generic_entities = sensor_module.create_entities_helper(
+        coordinator,
+        None,
+        sensor_module.DeviceType.INVERTER.value,
+        sensor_module.DEFAULT_INVERTER_PROFILE,
+    )
+    riv_entities = sensor_module.create_entities_helper(
+        coordinator,
+        None,
+        sensor_module.DeviceType.INVERTER.value,
+        sensor_module.RIV4835CSH1S_INVERTER_PROFILE,
+    )
+
+    assert "line_charging_current" not in {
+        entity.entity_description.key for entity in generic_entities
+    }
+    assert "line_charging_current" in {
+        entity.entity_description.key for entity in riv_entities
+    }


### PR DESCRIPTION
## Summary

- add Generic and RIV4835CSH1S inverter profile selection during setup and reconfiguration
- pass the selected model hint through standard and Communication Hub coordinators and preserve it across BLE service-info refreshes
- expose RIV4835CSH1S line charging current telemetry while leaving generic inverter entities unchanged
- document profile selection and add coverage for persistence, coordinator wiring, refresh behavior, and entity creation

## Validation

- uv run ruff format .
- uv run ruff check . --output-format=github
- uv run ty check . --output-format=github
- uv run pytest tests: 158 passed
- independent uncommitted-diff review found no actionable defects

Closes #167