### PR TITLE
feat: add Communication Hub communicating bank sensors

### DIFF
--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -108,9 +108,7 @@ class RenogyHubBatteryManager:
         remaining_capacity = _sum_complete(
             communicating, "battery_remaining_capacity", precision=3
         )
-        nominal_capacity = _sum_complete(
-            communicating, "battery_capacity", precision=3
-        )
+        nominal_capacity = _sum_complete(communicating, "battery_capacity", precision=3)
 
         percentage: float | None = None
         if (
@@ -126,9 +124,7 @@ class RenogyHubBatteryManager:
             battery_current=_sum_complete(
                 communicating, "battery_current", precision=2
             ),
-            battery_power=_sum_complete(
-                communicating, "battery_power", precision=3
-            ),
+            battery_power=_sum_complete(communicating, "battery_power", precision=3),
             battery_remaining_capacity=remaining_capacity,
             battery_capacity=nominal_capacity,
             battery_percentage=percentage,

--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -36,9 +36,39 @@ class RenogyHubBatteryState:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class RenogyHubBankState:
+    """Derived telemetry for batteries currently communicating through the Hub."""
+
+    communicating_battery_count: int
+    discovered_battery_count: int
+    battery_current: float | None
+    battery_power: float | None
+    battery_remaining_capacity: float | None
+    battery_capacity: float | None
+    battery_percentage: float | None
+
+    def as_dict(self) -> dict[str, float | int | None]:
+        """Return derived communicating-bank telemetry."""
+        return {
+            "communicating_battery_count": self.communicating_battery_count,
+            "discovered_battery_count": self.discovered_battery_count,
+            "battery_current": self.battery_current,
+            "battery_power": self.battery_power,
+            "battery_remaining_capacity": self.battery_remaining_capacity,
+            "battery_capacity": self.battery_capacity,
+            "battery_percentage": self.battery_percentage,
+        }
+
+
 def hub_battery_identifier(address: str, slave_id: int) -> str:
     """Return a stable logical device identifier below one physical BLE address."""
     return f"{address}:hub:{slave_id:02X}"
+
+
+def hub_bank_identifier(address: str) -> str:
+    """Return a stable logical identifier for the communicating battery bank."""
+    return f"{address}:hub:bank"
 
 
 class RenogyHubBatteryManager:
@@ -66,6 +96,43 @@ class RenogyHubBatteryManager:
     def batteries(self) -> tuple[RenogyHubBatteryState, ...]:
         """Return cached batteries ordered by Modbus slave ID."""
         return tuple(self._batteries[key] for key in sorted(self._batteries))
+
+    @property
+    def bank(self) -> RenogyHubBankState | None:
+        """Return aggregates for batteries that are currently communicating."""
+        batteries = self.batteries
+        if not batteries:
+            return None
+
+        communicating = tuple(battery for battery in batteries if battery.available)
+        remaining_capacity = _sum_complete(
+            communicating, "battery_remaining_capacity", precision=3
+        )
+        nominal_capacity = _sum_complete(
+            communicating, "battery_capacity", precision=3
+        )
+
+        percentage: float | None = None
+        if (
+            remaining_capacity is not None
+            and nominal_capacity is not None
+            and nominal_capacity > 0
+        ):
+            percentage = round(remaining_capacity / nominal_capacity * 100, 1)
+
+        return RenogyHubBankState(
+            communicating_battery_count=len(communicating),
+            discovered_battery_count=len(batteries),
+            battery_current=_sum_complete(
+                communicating, "battery_current", precision=2
+            ),
+            battery_power=_sum_complete(
+                communicating, "battery_power", precision=3
+            ),
+            battery_remaining_capacity=remaining_capacity,
+            battery_capacity=nominal_capacity,
+            battery_percentage=percentage,
+        )
 
     def get_battery(self, slave_id: int) -> RenogyHubBatteryState | None:
         """Return cached state for one Hub battery."""
@@ -109,6 +176,25 @@ class RenogyHubBatteryManager:
             battery_capacity=_optional_float(data.get("battery_capacity")),
             battery_percentage=_optional_float(data.get("battery_percentage")),
         )
+
+
+def _sum_complete(
+    batteries: tuple[RenogyHubBatteryState, ...],
+    field: str,
+    *,
+    precision: int,
+) -> float | None:
+    """Sum a field only when every communicating battery has a valid value."""
+    if not batteries:
+        return None
+
+    values: list[float] = []
+    for battery in batteries:
+        value = getattr(battery, field)
+        if value is None:
+            return None
+        values.append(float(value))
+    return round(sum(values), precision)
 
 
 def _optional_float(value: Any) -> float | None:

--- a/custom_components/renogy/hub_coordinator.py
+++ b/custom_components/renogy/hub_coordinator.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Any
 
 from .ble import RenogyActiveBluetoothCoordinator, RenogyBLEDevice
-from .hub import RenogyHubBatteryManager, RenogyHubBatteryState
+from .hub import RenogyHubBankState, RenogyHubBatteryManager, RenogyHubBatteryState
 
 HubManagerFactory = Callable[[Any], RenogyHubBatteryManager]
 HUB_REDISCOVERY_INTERVAL_SECONDS = 60 * 60
@@ -39,6 +39,13 @@ class RenogyHubBluetoothCoordinator(RenogyActiveBluetoothCoordinator):
         if self._hub_battery_manager is None:
             return ()
         return self._hub_battery_manager.batteries
+
+    @property
+    def hub_bank(self) -> RenogyHubBankState | None:
+        """Return derived telemetry for currently communicating Hub batteries."""
+        if self._hub_battery_manager is None:
+            return None
+        return self._hub_battery_manager.bank
 
     async def _read_device_data(self, service_info: Any) -> bool:
         """Read the primary device, then poll Hub batteries when enabled."""

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -25,7 +25,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import ATTR_MANUFACTURER, DOMAIN
-from .hub import RenogyHubBatteryState, hub_battery_identifier
+from .hub import (
+    RenogyHubBankState,
+    RenogyHubBatteryState,
+    hub_bank_identifier,
+    hub_battery_identifier,
+)
 
 HUB_BATTERY_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -76,21 +81,78 @@ HUB_BATTERY_SENSORS: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+HUB_BANK_COUNT_KEYS = frozenset(
+    {"communicating_battery_count", "discovered_battery_count"}
+)
+
+HUB_BANK_SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="communicating_battery_count",
+        name="Communicating Battery Count",
+        suggested_display_precision=0,
+    ),
+    SensorEntityDescription(
+        key="discovered_battery_count",
+        name="Discovered Battery Count",
+        suggested_display_precision=0,
+    ),
+    SensorEntityDescription(
+        key="battery_current",
+        name="Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    SensorEntityDescription(
+        key="battery_power",
+        name="Power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+    ),
+    SensorEntityDescription(
+        key="battery_remaining_capacity",
+        name="Remaining Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+    ),
+    SensorEntityDescription(
+        key="battery_capacity",
+        name="Nominal Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+    ),
+    SensorEntityDescription(
+        key="battery_percentage",
+        name="State of Charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+)
+
 
 def setup_hub_battery_sensors(
     config_entry: ConfigEntry,
     coordinator: Any,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Add logical Hub battery sensors as responder slave IDs are discovered."""
+    """Add logical Hub battery and communicating-bank sensors on discovery."""
     if getattr(coordinator, "communication_hub_enabled", False) is not True:
         return
 
     initialized_slave_ids: set[int] = set()
+    bank_initialized = False
 
     @callback
-    def _add_discovered_batteries() -> None:
-        new_entities: list[RenogyHubBatterySensor] = []
+    def _add_discovered_hub_entities() -> None:
+        nonlocal bank_initialized
+        new_entities: list[SensorEntity] = []
         for battery in coordinator.hub_batteries:
             if battery.slave_id in initialized_slave_ids:
                 continue
@@ -105,13 +167,23 @@ def setup_hub_battery_sensors(
                 for description in HUB_BATTERY_SENSORS
             )
 
+        if not bank_initialized and coordinator.hub_bank is not None:
+            bank_initialized = True
+            new_entities.extend(
+                RenogyHubBankSensor(
+                    coordinator=coordinator,
+                    description=description,
+                )
+                for description in HUB_BANK_SENSORS
+            )
+
         if new_entities:
             async_add_entities(new_entities)
 
     config_entry.async_on_unload(
-        coordinator.async_add_listener(_add_discovered_batteries)
+        coordinator.async_add_listener(_add_discovered_hub_entities)
     )
-    _add_discovered_batteries()
+    _add_discovered_hub_entities()
 
 
 class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
@@ -179,3 +251,67 @@ class RenogyHubBatterySensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, str]:
         """Expose the validated Modbus slave ID for diagnostics."""
         return {"slave_id": f"0x{self._slave_id:02X}"}
+
+
+class RenogyHubBankSensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
+    """Sensor derived from batteries currently communicating through the Hub."""
+
+    entity_description: SensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: Any,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize one communicating-bank sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        logical_id = hub_bank_identifier(coordinator.address)
+
+        self._attr_has_entity_name = True
+        self._attr_name = cast(str | None, description.name)
+        self._attr_unique_id = f"{logical_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, logical_id)},
+            name="Renogy Hub Communicating Bank",
+            manufacturer=ATTR_MANUFACTURER,
+            via_device=(DOMAIN, coordinator.address),
+        )
+
+    @property
+    def _bank(self) -> RenogyHubBankState | None:
+        """Return the latest derived communicating-bank state."""
+        coordinator = cast(Any, self.coordinator)
+        return coordinator.hub_bank
+
+    @property
+    def available(self) -> bool:
+        """Return whether this bank value can be stated from current Hub data."""
+        coordinator = cast(Any, self.coordinator)
+        parent_device = coordinator.device
+        bank = self._bank
+        if parent_device is None or not parent_device.is_available or bank is None:
+            return False
+
+        key = self.entity_description.key
+        if key in HUB_BANK_COUNT_KEYS:
+            return True
+        if key is None:
+            return False
+        return getattr(bank, key, None) is not None
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return this sensor's derived communicating-bank value."""
+        bank = self._bank
+        if bank is None:
+            return None
+        key = self.entity_description.key
+        if key is None:
+            return None
+        value = getattr(bank, key, None)
+        if value is None:
+            return None
+        if key in HUB_BANK_COUNT_KEYS:
+            return int(value)
+        return float(value)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -427,7 +427,4 @@ def test_hub_battery_identifier_is_stable_and_slave_specific() -> None:
 
 def test_hub_bank_identifier_is_stable() -> None:
     """The communicating bank should have one stable logical device identifier."""
-    assert (
-        hub_bank_identifier("F0:F8:F2:57:47:0D")
-        == "F0:F8:F2:57:47:0D:hub:bank"
-    )
+    assert hub_bank_identifier("F0:F8:F2:57:47:0D") == "F0:F8:F2:57:47:0D:hub:bank"

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -32,6 +32,7 @@ def _load_hub_module() -> Any:
 
 hub_module = _load_hub_module()
 RenogyHubBatteryManager = hub_module.RenogyHubBatteryManager
+hub_bank_identifier = hub_module.hub_bank_identifier
 hub_battery_identifier = hub_module.hub_battery_identifier
 
 
@@ -105,6 +106,167 @@ def test_hub_manager_caches_validated_fields() -> None:
         "battery_capacity": 49.995,
         "battery_percentage": 84.8,
     }
+
+
+def test_hub_manager_builds_communicating_bank_aggregates() -> None:
+    """Bank telemetry should aggregate all currently communicating batteries."""
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=49.6,
+                        battery_current=-2.87,
+                        battery_power=-142.352,
+                        battery_remaining_capacity=45.695,
+                        battery_capacity=49.993,
+                        battery_percentage=91.4,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_voltage=49.7,
+                        battery_current=-1.53,
+                        battery_power=-76.041,
+                        battery_remaining_capacity=47.494,
+                        battery_capacity=49.993,
+                        battery_percentage=95.0,
+                    ),
+                    _battery(
+                        0x32,
+                        battery_voltage=49.7,
+                        battery_current=-1.87,
+                        battery_power=-92.939,
+                        battery_remaining_capacity=46.818,
+                        battery_capacity=49.993,
+                        battery_percentage=93.6,
+                    ),
+                    _battery(
+                        0x33,
+                        battery_voltage=49.7,
+                        battery_current=-0.82,
+                        battery_power=-40.754,
+                        battery_remaining_capacity=48.277,
+                        battery_capacity=49.995,
+                        battery_percentage=96.6,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    assert asyncio.run(manager.async_update(object())) is True
+
+    bank = manager.bank
+    assert bank is not None
+    assert bank.as_dict() == {
+        "communicating_battery_count": 4,
+        "discovered_battery_count": 4,
+        "battery_current": -7.09,
+        "battery_power": -352.086,
+        "battery_remaining_capacity": 188.284,
+        "battery_capacity": 199.974,
+        "battery_percentage": 94.2,
+    }
+
+
+def test_hub_manager_excludes_unavailable_battery_from_bank() -> None:
+    """A missed battery should remain discovered but leave bank aggregates."""
+    timeout_error = TimeoutError("battery timeout")
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_current=-2.0,
+                        battery_power=-100.0,
+                        battery_remaining_capacity=40.0,
+                        battery_capacity=50.0,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_current=-1.0,
+                        battery_power=-50.0,
+                        battery_remaining_capacity=45.0,
+                        battery_capacity=50.0,
+                    ),
+                ],
+            ),
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_current=-2.2,
+                        battery_power=-110.0,
+                        battery_remaining_capacity=39.0,
+                        battery_capacity=50.0,
+                    )
+                ],
+                timeout_error,
+            ),
+        ]
+    )
+
+    async def _run() -> None:
+        assert await manager.async_update(object()) is True
+        assert await manager.async_update(object()) is True
+
+    asyncio.run(_run())
+
+    bank = manager.bank
+    assert bank is not None
+    assert bank.as_dict() == {
+        "communicating_battery_count": 1,
+        "discovered_battery_count": 2,
+        "battery_current": -2.2,
+        "battery_power": -110.0,
+        "battery_remaining_capacity": 39.0,
+        "battery_capacity": 50.0,
+        "battery_percentage": 78.0,
+    }
+
+
+def test_hub_manager_requires_complete_fields_for_each_bank_metric() -> None:
+    """A missing value on a communicating battery must not yield a partial total."""
+    manager, _hub = _manager(
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_current=-2.0,
+                        battery_power=-100.0,
+                        battery_remaining_capacity=40.0,
+                        battery_capacity=50.0,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_current=None,
+                        battery_power=-50.0,
+                        battery_remaining_capacity=45.0,
+                        battery_capacity=50.0,
+                    ),
+                ],
+            )
+        ]
+    )
+
+    asyncio.run(manager.async_update(object()))
+
+    bank = manager.bank
+    assert bank is not None
+    assert bank.communicating_battery_count == 2
+    assert bank.discovered_battery_count == 2
+    assert bank.battery_current is None
+    assert bank.battery_power == -150.0
+    assert bank.battery_remaining_capacity == 85.0
+    assert bank.battery_capacity == 100.0
+    assert bank.battery_percentage == 85.0
 
 
 def test_hub_manager_marks_missing_cached_battery_unavailable() -> None:
@@ -210,8 +372,22 @@ def test_hub_manager_marks_all_cached_batteries_unavailable() -> None:
             _FakeResult(
                 True,
                 [
-                    _battery(0x30, battery_voltage=49.8),
-                    _battery(0x31, battery_voltage=49.7),
+                    _battery(
+                        0x30,
+                        battery_voltage=49.8,
+                        battery_current=-2.0,
+                        battery_power=-100.0,
+                        battery_remaining_capacity=40.0,
+                        battery_capacity=50.0,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_voltage=49.7,
+                        battery_current=-1.0,
+                        battery_power=-50.0,
+                        battery_remaining_capacity=45.0,
+                        battery_capacity=50.0,
+                    ),
                 ],
             )
         ]
@@ -223,6 +399,22 @@ def test_hub_manager_marks_all_cached_batteries_unavailable() -> None:
 
     assert manager.last_error is error
     assert all(not battery.available for battery in manager.batteries)
+    bank = manager.bank
+    assert bank is not None
+    assert bank.communicating_battery_count == 0
+    assert bank.discovered_battery_count == 2
+    assert bank.battery_current is None
+    assert bank.battery_power is None
+    assert bank.battery_remaining_capacity is None
+    assert bank.battery_capacity is None
+    assert bank.battery_percentage is None
+
+
+def test_hub_manager_has_no_bank_before_any_battery_is_discovered() -> None:
+    """The logical bank should not exist until at least one battery is discovered."""
+    manager, _hub = _manager([])
+
+    assert manager.bank is None
 
 
 def test_hub_battery_identifier_is_stable_and_slave_specific() -> None:
@@ -231,3 +423,11 @@ def test_hub_battery_identifier_is_stable_and_slave_specific() -> None:
 
     assert hub_battery_identifier(address, 0x30) == "F0:F8:F2:57:47:0D:hub:30"
     assert hub_battery_identifier(address, 0x31) == "F0:F8:F2:57:47:0D:hub:31"
+
+
+def test_hub_bank_identifier_is_stable() -> None:
+    """The communicating bank should have one stable logical device identifier."""
+    assert (
+        hub_bank_identifier("F0:F8:F2:57:47:0D")
+        == "F0:F8:F2:57:47:0D:hub:bank"
+    )

--- a/tests/test_hub_coordinator.py
+++ b/tests/test_hub_coordinator.py
@@ -59,6 +59,9 @@ def _load_hub_coordinator_module() -> Any:
     class RenogyHubBatteryState:
         """Minimal cached Hub state placeholder."""
 
+    class RenogyHubBankState:
+        """Minimal derived Hub bank placeholder."""
+
     class RenogyHubBatteryManager:
         """Default manager placeholder; tests inject a fake manager factory."""
 
@@ -66,6 +69,7 @@ def _load_hub_coordinator_module() -> Any:
             raise AssertionError("Tests should inject a Hub manager factory")
 
     hub_module.RenogyHubBatteryState = RenogyHubBatteryState
+    hub_module.RenogyHubBankState = RenogyHubBankState
     hub_module.RenogyHubBatteryManager = RenogyHubBatteryManager
     sys.modules["custom_components.renogy.hub"] = hub_module
 
@@ -82,10 +86,12 @@ class _FakeHubManager:
         results: list[bool] | None = None,
         error: Exception | None = None,
         batteries: tuple[Any, ...] = (),
+        bank: Any | None = None,
     ) -> None:
         self._results = list(results or [True])
         self._error = error
         self.batteries = batteries
+        self.bank = bank
         self.last_error: Exception | None = None
         self.calls: list[bool] = []
         self.unavailable_errors: list[Exception] = []
@@ -127,7 +133,18 @@ def test_hub_coordinator_is_disabled_by_default() -> None:
 
     assert coordinator.communication_hub_enabled is False
     assert coordinator.hub_batteries == ()
+    assert coordinator.hub_bank is None
     assert asyncio.run(coordinator._read_device_data(object())) is True
+
+
+def test_hub_coordinator_exposes_manager_bank_state() -> None:
+    """The coordinator should expose the manager's derived bank state."""
+    module = _load_hub_coordinator_module()
+    bank = object()
+    manager = _FakeHubManager(bank=bank)
+    coordinator = _coordinator(module, manager)
+
+    assert coordinator.hub_bank is bank
 
 
 def test_hub_coordinator_discovers_once_then_uses_cached_polling() -> None:

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -275,13 +275,20 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_and_bank_once() -> None:
 
     assert len(added_batches) == 1
     assert len(added_batches[0]) == 19
-    assert sum(
-        isinstance(entity, module.RenogyHubBatterySensor)
-        for entity in added_batches[0]
-    ) == 12
-    assert sum(
-        isinstance(entity, module.RenogyHubBankSensor) for entity in added_batches[0]
-    ) == 7
+    assert (
+        sum(
+            isinstance(entity, module.RenogyHubBatterySensor)
+            for entity in added_batches[0]
+        )
+        == 12
+    )
+    assert (
+        sum(
+            isinstance(entity, module.RenogyHubBankSensor)
+            for entity in added_batches[0]
+        )
+        == 7
+    )
     assert {
         entity._slave_id
         for entity in added_batches[0]
@@ -304,8 +311,7 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_and_bank_once() -> None:
     assert len(added_batches) == 2
     assert len(added_batches[1]) == 6
     assert all(
-        isinstance(entity, module.RenogyHubBatterySensor)
-        for entity in added_batches[1]
+        isinstance(entity, module.RenogyHubBatterySensor) for entity in added_batches[1]
     )
     assert {entity._slave_id for entity in added_batches[1]} == {0x31}
 

--- a/tests/test_hub_sensor.py
+++ b/tests/test_hub_sensor.py
@@ -24,6 +24,17 @@ class _BatteryState:
     available: bool = True
 
 
+@dataclass(frozen=True, slots=True)
+class _BankState:
+    communicating_battery_count: int
+    discovered_battery_count: int
+    battery_current: float | None = None
+    battery_power: float | None = None
+    battery_remaining_capacity: float | None = None
+    battery_capacity: float | None = None
+    battery_percentage: float | None = None
+
+
 class _Coordinator:
     def __init__(self) -> None:
         self.address = "F0:F8:F2:57:47:0D"
@@ -31,6 +42,7 @@ class _Coordinator:
         self.last_update_success = True
         self.device = SimpleNamespace(is_available=True)
         self.hub_batteries: tuple[_BatteryState, ...] = ()
+        self.hub_bank: _BankState | None = None
         self.listeners: list[Any] = []
 
     def async_add_listener(self, callback: Any, context: Any = None) -> Any:
@@ -185,9 +197,11 @@ def _install_module_stubs() -> None:
 
     hub_stub = cast(Any, types.ModuleType("custom_components.renogy.hub"))
     hub_stub.RenogyHubBatteryState = _BatteryState
+    hub_stub.RenogyHubBankState = _BankState
     hub_stub.hub_battery_identifier = lambda address, slave_id: (
         f"{address}:hub:{slave_id:02X}"
     )
+    hub_stub.hub_bank_identifier = lambda address: f"{address}:hub:bank"
     sys.modules["custom_components.renogy.hub"] = hub_stub
 
 
@@ -222,9 +236,18 @@ def test_hub_sensor_descriptions_expose_only_validated_telemetry() -> None:
         "battery_capacity",
         "battery_percentage",
     }
+    assert {description.key for description in module.HUB_BANK_SENSORS} == {
+        "communicating_battery_count",
+        "discovered_battery_count",
+        "battery_current",
+        "battery_power",
+        "battery_remaining_capacity",
+        "battery_capacity",
+        "battery_percentage",
+    }
 
 
-def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
+def test_hub_sensor_setup_adds_noncontiguous_responders_and_bank_once() -> None:
     module = _load_hub_sensor_module()
     coordinator = _Coordinator()
     config_entry = _ConfigEntry()
@@ -244,11 +267,26 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
         _BatteryState(slave_id=0x30, battery_voltage=50.5),
         _BatteryState(slave_id=0x33, battery_voltage=50.4),
     )
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=2,
+        discovered_battery_count=2,
+    )
     coordinator.notify()
 
     assert len(added_batches) == 1
-    assert len(added_batches[0]) == 12
-    assert {entity._slave_id for entity in added_batches[0]} == {0x30, 0x33}
+    assert len(added_batches[0]) == 19
+    assert sum(
+        isinstance(entity, module.RenogyHubBatterySensor)
+        for entity in added_batches[0]
+    ) == 12
+    assert sum(
+        isinstance(entity, module.RenogyHubBankSensor) for entity in added_batches[0]
+    ) == 7
+    assert {
+        entity._slave_id
+        for entity in added_batches[0]
+        if isinstance(entity, module.RenogyHubBatterySensor)
+    } == {0x30, 0x33}
 
     coordinator.notify()
     assert len(added_batches) == 1
@@ -257,10 +295,18 @@ def test_hub_sensor_setup_adds_noncontiguous_responders_once() -> None:
         *coordinator.hub_batteries,
         _BatteryState(slave_id=0x31, battery_voltage=50.5),
     )
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=3,
+        discovered_battery_count=3,
+    )
     coordinator.notify()
 
     assert len(added_batches) == 2
     assert len(added_batches[1]) == 6
+    assert all(
+        isinstance(entity, module.RenogyHubBatterySensor)
+        for entity in added_batches[1]
+    )
     assert {entity._slave_id for entity in added_batches[1]} == {0x31}
 
 
@@ -304,6 +350,105 @@ def test_hub_battery_0x33_is_child_device_with_validated_values() -> None:
     )
     assert voltage._attr_device_info["name"] == "Renogy Hub Battery 0x33"
     assert voltage.extra_state_attributes == {"slave_id": "0x33"}
+
+
+def test_hub_bank_is_sibling_device_with_aggregate_values() -> None:
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=4,
+        discovered_battery_count=4,
+        battery_current=-7.09,
+        battery_power=-352.086,
+        battery_remaining_capacity=188.284,
+        battery_capacity=199.974,
+        battery_percentage=94.2,
+    )
+
+    entities = [
+        module.RenogyHubBankSensor(coordinator, description)
+        for description in module.HUB_BANK_SENSORS
+    ]
+    entities_by_key = {entity.entity_description.key: entity for entity in entities}
+
+    assert entities_by_key["communicating_battery_count"].native_value == 4
+    assert entities_by_key["discovered_battery_count"].native_value == 4
+    assert entities_by_key["battery_current"].native_value == -7.09
+    assert entities_by_key["battery_power"].native_value == -352.086
+    assert entities_by_key["battery_remaining_capacity"].native_value == 188.284
+    assert entities_by_key["battery_capacity"].native_value == 199.974
+    assert entities_by_key["battery_percentage"].native_value == 94.2
+
+    current = entities_by_key["battery_current"]
+    assert current.available is True
+    assert current._attr_unique_id == "F0:F8:F2:57:47:0D:hub:bank_battery_current"
+    assert current._attr_device_info["identifiers"] == {
+        ("renogy", "F0:F8:F2:57:47:0D:hub:bank")
+    }
+    assert current._attr_device_info["via_device"] == (
+        "renogy",
+        "F0:F8:F2:57:47:0D",
+    )
+    assert current._attr_device_info["name"] == "Renogy Hub Communicating Bank"
+
+
+def test_hub_bank_counts_remain_available_when_all_batteries_are_offline() -> None:
+    """Counts should show a partial/offline bank while aggregates go unavailable."""
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=0,
+        discovered_battery_count=4,
+    )
+
+    entities = {
+        description.key: module.RenogyHubBankSensor(coordinator, description)
+        for description in module.HUB_BANK_SENSORS
+    }
+
+    assert entities["communicating_battery_count"].available is True
+    assert entities["communicating_battery_count"].native_value == 0
+    assert entities["discovered_battery_count"].available is True
+    assert entities["discovered_battery_count"].native_value == 4
+    assert entities["battery_current"].available is False
+    assert entities["battery_power"].available is False
+    assert entities["battery_remaining_capacity"].available is False
+    assert entities["battery_capacity"].available is False
+    assert entities["battery_percentage"].available is False
+
+    coordinator.device.is_available = False
+    assert entities["communicating_battery_count"].available is False
+    assert entities["discovered_battery_count"].available is False
+
+
+def test_hub_bank_metric_recovers_when_data_returns() -> None:
+    """A bank metric should become available again when complete data returns."""
+    module = _load_hub_sensor_module()
+    coordinator = _Coordinator()
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=2,
+        discovered_battery_count=2,
+        battery_current=None,
+    )
+    entity = module.RenogyHubBankSensor(
+        coordinator,
+        next(
+            description
+            for description in module.HUB_BANK_SENSORS
+            if description.key == "battery_current"
+        ),
+    )
+
+    assert entity.available is False
+    assert entity.native_value is None
+
+    coordinator.hub_bank = _BankState(
+        communicating_battery_count=2,
+        discovered_battery_count=2,
+        battery_current=-3.25,
+    )
+    assert entity.available is True
+    assert entity.native_value == -3.25
 
 
 def test_hub_battery_sensor_tracks_logical_battery_availability() -> None:


### PR DESCRIPTION
## Summary

Add a logical Communication Hub bank device that derives aggregate telemetry from the Hub batteries currently communicating with Home Assistant.

The bank is computed entirely from the existing `RenogyHubBatteryManager` cache, so this introduces no additional BLE or Modbus requests and does not change the existing child-battery device identities.

## Sensors

The new `Renogy Hub Communicating Bank` device exposes:

- Communicating Battery Count
- Discovered Battery Count
- Current
- Power
- Remaining Capacity
- Nominal Capacity
- State of Charge

## Partial-bank semantics

- Aggregates use only batteries whose cached Hub state is currently `available`.
- A previously discovered battery that stops responding remains counted as discovered but is excluded from communicating-bank totals.
- If all discovered batteries are unavailable, the count sensors remain available (`0` communicating / `N` discovered) while Current, Power, Capacity, and SOC become unavailable.
- If a communicating battery is missing a field required by one aggregate, that aggregate becomes unavailable rather than silently producing a partial total.
- State of Charge is capacity-weighted (`remaining capacity / nominal capacity`) rather than an average of individual SOC percentages.
- Parent inverter availability behavior is unchanged.

## Device model

The bank uses a stable logical identifier beneath the existing physical BLE parent:

`<BLE address>:hub:bank`

Existing logical Hub battery identifiers remain unchanged.

## Validation

- focused Hub manager/coordinator/sensor tests: 27 passed
- includes captured four-battery hardware values for aggregate Current, Power, Capacity, and weighted SOC
- covers one-battery loss, all-battery loss, incomplete telemetry, recovery, stable identifiers, and create-once entity behavior

## Transport impact

No additional BLE or Modbus traffic is introduced. All seven values are derived in `renogy-ha` from telemetry already being polled for the individual Hub batteries.