### PR TITLE
build(deps): update renogy-ble to 2.6.1

### DIFF
--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -38,7 +38,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.6.0"
+    "renogy-ble==2.6.1"
   ],
   "version": "0.9.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2026.3.0",
-    "renogy-ble==2.6.0",
+    "renogy-ble==2.6.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1533,15 +1533,15 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.6.0"
+version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/f2/7f0683851262e88c58bcea33bdf460168ea2cd0ec43db8d4ae756628e755/renogy_ble-2.6.0.tar.gz", hash = "sha256:bbd84b0a711817570c6ea59857fdde2cca7f46119ace992dae0103a97a75e9c4", size = 79935, upload-time = "2026-08-23T19:17:57.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/58/11bc27fec53fd7d382da3a737e1a5a3fad5d0d6c79f30d42294f5c9f2586/renogy_ble-2.6.1.tar.gz", hash = "sha256:9b1c7d367a2bfbcfd7dac0edab89907ace01e39795405dd011f1fca26782802d", size = 80643, upload-time = "2026-09-03T02:09:59.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/c0/db8000a75023f02824e99c3f367f2118195246bd9ce805f6132fa3fec10a/renogy_ble-2.6.0-py3-none-any.whl", hash = "sha256:8f68083f070ae5b28e364ed3e0bf2ae1acff37a544fe29d3a53c78d4bb1975b0", size = 36539, upload-time = "2026-08-23T19:17:56.203Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5d/722756e8e77c143036a79777c4118f9c367d4f8e4624a53cc308d5a2901b/renogy_ble-2.6.1-py3-none-any.whl", hash = "sha256:f7a73c594de0e56625a498ff5bb007c5da6c57b20c26579c936eec60219cb720", size = 36869, upload-time = "2026-09-03T02:09:58.333Z" },
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "renogy-ble", specifier = "==2.6.0" },
+    { name = "renogy-ble", specifier = "==2.6.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary\n\n- Update renogy-ble from 2.6.0 to 2.6.1 in the project dependency and HACS manifest.\n- Regenerate uv.lock with the 2.6.1 artifact hashes.\n\n## Validation\n\n- uv lock --check\n- Ruff format and check\n- ty check\n- pytest tests (167 passed)