### PR TITLE
feat: add RIV4835CSH1S maximum AC charging current control

### DIFF
--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -131,6 +131,12 @@ class InverterRegister:
     AC_INPUT_CURRENT_LIMIT = 0x1168
 
 
+class RIV4835CSH1SRegister:
+    """Hardware-validated RIV4835CSH1S setting registers."""
+
+    MAX_AC_CHARGING_CURRENT = 0xE205
+
+
 # DCC Battery Type Values
 DCC_BATTERY_TYPES = {
     0: "custom",

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -38,7 +38,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble==2.6.1"
+    "renogy-ble@git+https://github.com/codefendant/renogy-ble.git@88f6fd7090f582ecad79a1c1254d98db15fd630b"
   ],
   "version": "0.9.0"
 }

--- a/custom_components/renogy/manifest.json
+++ b/custom_components/renogy/manifest.json
@@ -38,7 +38,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/IAmTheMitchell/renogy-ha/issues",
   "requirements": [
-    "renogy-ble@git+https://github.com/codefendant/renogy-ble.git@88f6fd7090f582ecad79a1c1254d98db15fd630b"
+    "renogy-ble==2.7.0"
   ],
   "version": "0.9.0"
 }

--- a/custom_components/renogy/number.py
+++ b/custom_components/renogy/number.py
@@ -28,13 +28,17 @@ from .const import (
     ATTR_MANUFACTURER,
     CONF_DEVICE_NAME,
     CONF_DEVICE_TYPE,
+    CONF_INVERTER_PROFILE,
     DEFAULT_DEVICE_TYPE,
+    DEFAULT_INVERTER_PROFILE,
     DOMAIN,
     LOGGER,
     RENOGY_REGO_INVERTER_PREFIX,
+    RIV4835CSH1S_INVERTER_PROFILE,
     DCCRegister,
     DeviceType,
     InverterRegister,
+    RIV4835CSH1SRegister,
 )
 
 
@@ -334,6 +338,28 @@ INVERTER_ALL_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
     ),
 )
 
+# RIV4835CSH1S Program 28: Maximum AC Charging Current.
+# Hardware validation confirmed register 0xE205 with 0.1 A scaling:
+# 0 A -> raw 0, 5 A -> raw 50, 10 A -> raw 100. Function 0x06 writes changed the
+# physical LCD in both directions, and 0 A disabled utility battery charging while
+# preserving AC bypass and solar charging. The RIV polling profile provides live
+# readback under the model-specific key below.
+RIV4835CSH1S_NUMBERS: tuple[RenogyNumberEntityDescription, ...] = (
+    RenogyNumberEntityDescription(
+        key="inverter_ac_charge_current",
+        name="Maximum AC Charging Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=NumberDeviceClass.CURRENT,
+        native_min_value=0.0,
+        native_max_value=40.0,
+        native_step=5.0,
+        mode=NumberMode.BOX,
+        entity_category=EntityCategory.CONFIG,
+        register=RIV4835CSH1SRegister.MAX_AC_CHARGING_CURRENT,
+        scale=10.0,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -348,12 +374,20 @@ async def async_setup_entry(
     renogy_data = hass.data[DOMAIN][config_entry.entry_id]
     coordinator = renogy_data["coordinator"]
 
-    # Get device type from config
+    # Get device type and model-specific inverter profile from config.
     device_type = config_entry.data.get(CONF_DEVICE_TYPE, DEFAULT_DEVICE_TYPE)
+    inverter_profile = config_entry.data.get(
+        CONF_INVERTER_PROFILE, DEFAULT_INVERTER_PROFILE
+    )
 
-    # Select the number descriptions for this device type
+    # Select the number descriptions for this device type/profile.
     if device_type == DeviceType.DCC.value:
         descriptions = DCC_ALL_NUMBERS
+    elif (
+        device_type == DeviceType.INVERTER.value
+        and inverter_profile == RIV4835CSH1S_INVERTER_PROFILE
+    ):
+        descriptions = RIV4835CSH1S_NUMBERS
     elif device_type == DeviceType.INVERTER.value and str(
         config_entry.data.get(CONF_DEVICE_NAME, "")
     ).startswith(RENOGY_REGO_INVERTER_PREFIX):
@@ -484,7 +518,8 @@ class RenogyNumberEntity(NumberEntity):
 
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        # Clear cached value to force a refresh
+        # Clear the optimistic local value so the coordinator's live device
+        # readback becomes authoritative after every refresh.
         self._attr_native_value = None
 
         # Update device reference if needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14.2"
 dependencies = [
     "homeassistant>=2026.3.0",
-    "renogy-ble==2.6.1",
+    "renogy-ble==2.7.0",
 ]
 
 [dependency-groups]

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -312,6 +312,55 @@ def test_inverter_numbers_cover_registers() -> None:
     )
 
 
+def test_riv4835_program_28_number_matches_validated_range() -> None:
+    """Expose only the hardware-validated RIV4835 Program 28 setpoint."""
+    number = _load_number_module()
+
+    assert len(number.RIV4835CSH1S_NUMBERS) == 1
+    description = number.RIV4835CSH1S_NUMBERS[0]
+    assert description.key == "inverter_ac_charge_current"
+    assert description.name == "Maximum AC Charging Current"
+    assert description.register == 0xE205
+    assert description.scale == 10.0
+    assert (
+        description.native_min_value,
+        description.native_max_value,
+        description.native_step,
+    ) == (0.0, 40.0, 5.0)
+
+
+def test_riv4835_program_28_writes_and_uses_live_readback() -> None:
+    """Write Program 28 through 0xE205 and prefer subsequent device readback."""
+    number = _load_number_module()
+    description = number.RIV4835CSH1S_NUMBERS[0]
+
+    coordinator = MagicMock()
+    coordinator.address = "F0:F8:F2:57:47:0D"
+    coordinator.device = None
+    coordinator.data = {}
+    coordinator.async_write_register = AsyncMock(return_value=True)
+
+    entity = number.RenogyNumberEntity(
+        coordinator=coordinator,
+        device=None,
+        description=description,
+        device_type=number.DeviceType.INVERTER.value,
+    )
+    entity.async_write_ha_state = MagicMock()
+
+    asyncio.run(entity.async_set_native_value(10.0))
+
+    coordinator.async_write_register.assert_awaited_once_with(
+        number.RIV4835CSH1SRegister.MAX_AC_CHARGING_CURRENT,
+        100,
+    )
+    assert entity.native_value == 10.0
+
+    coordinator.data = {"inverter_ac_charge_current": 5.0}
+    entity._handle_coordinator_update()
+    assert entity.native_value == 5.0
+
+
 def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
     """Ensure async_setup_entry wires up the inverter number descriptions."""
     number = _load_number_module()
@@ -339,6 +388,32 @@ def test_inverter_number_setup_creates_entities_for_inverter_device() -> None:
     assert {e.entity_description.key for e in created_entities} == {
         d.key for d in number.INVERTER_ALL_NUMBERS
     }
+
+
+def test_riv4835_number_setup_uses_model_profile() -> None:
+    """RIV4835 entries should expose only the validated Program 28 control."""
+    number = _load_number_module()
+
+    coordinator = MagicMock()
+    coordinator.device = None
+    hass = MagicMock()
+    hass.data = {number.DOMAIN: {"entry-1": {"coordinator": coordinator}}}
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-1"
+    config_entry.data = {
+        number.CONF_DEVICE_TYPE: number.DeviceType.INVERTER.value,
+        number.CONF_DEVICE_NAME: "BT-TH-F257470D",
+        number.CONF_INVERTER_PROFILE: number.RIV4835CSH1S_INVERTER_PROFILE,
+    }
+    async_add_entities = MagicMock()
+
+    asyncio.run(number.async_setup_entry(hass, config_entry, async_add_entities))
+
+    async_add_entities.assert_called_once()
+    (created_entities,) = async_add_entities.call_args.args
+    assert len(created_entities) == 1
+    assert created_entities[0].entity_description is number.RIV4835CSH1S_NUMBERS[0]
 
 
 def test_inverter_number_setup_skips_non_rego_inverters() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1533,15 +1533,15 @@ wheels = [
 
 [[package]]
 name = "renogy-ble"
-version = "2.6.1"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bleak" },
     { name = "bleak-retry-connector" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/58/11bc27fec53fd7d382da3a737e1a5a3fad5d0d6c79f30d42294f5c9f2586/renogy_ble-2.6.1.tar.gz", hash = "sha256:9b1c7d367a2bfbcfd7dac0edab89907ace01e39795405dd011f1fca26782802d", size = 80643, upload-time = "2026-09-03T02:09:59.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/73/06c3d6de537b0c25847598992e5a4404e87a7f869d41a00864fd7bea128e/renogy_ble-2.7.0.tar.gz", hash = "sha256:bcb6921758cca0cb4296d7ebb25747549c406beb49c66df091d6c6f0228ef6eb", size = 82358, upload-time = "2026-09-10T02:45:00.368Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/5d/722756e8e77c143036a79777c4118f9c367d4f8e4624a53cc308d5a2901b/renogy_ble-2.6.1-py3-none-any.whl", hash = "sha256:f7a73c594de0e56625a498ff5bb007c5da6c57b20c26579c936eec60219cb720", size = 36869, upload-time = "2026-09-03T02:09:58.333Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/09/72de848797af493444d4369a4251b1b57e4d4e66fc763269044795d8bcd6/renogy_ble-2.7.0-py3-none-any.whl", hash = "sha256:e599d790a4d78f5579a033fcb49d80b1ed427c30cf33243552b40fab0e6be3a6", size = 37378, upload-time = "2026-09-10T02:44:59.395Z" },
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "renogy-ble", specifier = "==2.6.1" },
+    { name = "renogy-ble", specifier = "==2.7.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Add a model-specific Home Assistant Number entity for **RIV4835CSH1S Program 28 — Maximum AC Charging Current**.

The final implementation uses the hardware-validated Program 28 holding register `0xE205`, with `0.1 A` scaling and the inverter's physical `5 A` increment.

## Hardware validation

On a real RIV4835CSH1S:

- LCD `0 A` -> `0xE205 = 0`
- LCD `5 A` -> `0xE205 = 50`
- LCD `10 A` -> `0xE205 = 100`

The existing `renogy-ble` function-`0x06` write path was then validated in both directions:

- `5 A -> 10 A`: fresh read `50`, write `100`, exact CRC-valid echo, readback `100`, physical LCD changed to `10 A`
- `10 A -> 0 A`: fresh read `100`, write `0`, exact CRC-valid echo, readback `0`, physical LCD changed to `0 A`

At Program 28 = `0 A`, line charging fell to `0.0 A` while AC passthrough continued supplying the load and solar charging remained active.

## Home Assistant entity

For the `RIV4835CSH1S` profile only:

- key: `inverter_ac_charge_current`
- name: `Maximum AC Charging Current`
- register: `0xE205`
- range: `0–40 A`
- step: `5 A`
- write scaling: HA amps × `10`
- live readback from the RIV-specific `renogy-ble` polling profile

The earlier retained-value workaround has been removed; coordinator refreshes now make live device readback authoritative.

The generic/REGO inverter controls remain unchanged, including their existing `0x1146` total-charge-current setting.

## Dependency

Companion `renogy-ble` PR: IAmTheMitchell/renogy-ble#161

`renogy-ble` PR #161 has been merged and released in `renogy-ble==2.7.0`, so this PR now depends on that released version rather than the temporary fork commit pin used during hardware testing.

## Tests

- verifies the RIV entity uses `0xE205`, `0–40 A`, `5 A` steps, and ×10 write scaling
- verifies a `10 A` request writes raw `100`
- verifies subsequent coordinator readback replaces the optimistic locally-written value
- verifies only the RIV profile gets this control

Focused `tests/test_number.py` and Ruff checks pass on Python 3.14.