### PR TITLE
feat: add Communication Hub bank imbalance diagnostics

### DIFF
--- a/custom_components/renogy/hub.py
+++ b/custom_components/renogy/hub.py
@@ -47,9 +47,20 @@ class RenogyHubBankState:
     battery_remaining_capacity: float | None
     battery_capacity: float | None
     battery_percentage: float | None
+    battery_percentage_min: float | None = None
+    battery_percentage_min_slave_id: int | None = None
+    battery_percentage_max: float | None = None
+    battery_percentage_max_slave_id: int | None = None
+    battery_percentage_spread: float | None = None
+    battery_voltage_min: float | None = None
+    battery_voltage_min_slave_id: int | None = None
+    battery_voltage_max: float | None = None
+    battery_voltage_max_slave_id: int | None = None
+    battery_voltage_spread: float | None = None
+    battery_current_spread: float | None = None
 
     def as_dict(self) -> dict[str, float | int | None]:
-        """Return derived communicating-bank telemetry."""
+        """Return primary communicating-bank aggregate telemetry."""
         return {
             "communicating_battery_count": self.communicating_battery_count,
             "discovered_battery_count": self.discovered_battery_count,
@@ -59,6 +70,17 @@ class RenogyHubBankState:
             "battery_capacity": self.battery_capacity,
             "battery_percentage": self.battery_percentage,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class _HubRange:
+    """Complete min/max/spread telemetry for one battery field."""
+
+    minimum: float | None
+    minimum_slave_id: int | None
+    maximum: float | None
+    maximum_slave_id: int | None
+    spread: float | None
 
 
 def hub_battery_identifier(address: str, slave_id: int) -> str:
@@ -109,6 +131,15 @@ class RenogyHubBatteryManager:
             communicating, "battery_remaining_capacity", precision=3
         )
         nominal_capacity = _sum_complete(communicating, "battery_capacity", precision=3)
+        percentage_range = _range_complete(
+            communicating, "battery_percentage", precision=1
+        )
+        voltage_range = _range_complete(
+            communicating, "battery_voltage", precision=1
+        )
+        current_range = _range_complete(
+            communicating, "battery_current", precision=2
+        )
 
         percentage: float | None = None
         if (
@@ -128,6 +159,17 @@ class RenogyHubBatteryManager:
             battery_remaining_capacity=remaining_capacity,
             battery_capacity=nominal_capacity,
             battery_percentage=percentage,
+            battery_percentage_min=percentage_range.minimum,
+            battery_percentage_min_slave_id=percentage_range.minimum_slave_id,
+            battery_percentage_max=percentage_range.maximum,
+            battery_percentage_max_slave_id=percentage_range.maximum_slave_id,
+            battery_percentage_spread=percentage_range.spread,
+            battery_voltage_min=voltage_range.minimum,
+            battery_voltage_min_slave_id=voltage_range.minimum_slave_id,
+            battery_voltage_max=voltage_range.maximum,
+            battery_voltage_max_slave_id=voltage_range.maximum_slave_id,
+            battery_voltage_spread=voltage_range.spread,
+            battery_current_spread=current_range.spread,
         )
 
     def get_battery(self, slave_id: int) -> RenogyHubBatteryState | None:
@@ -191,6 +233,34 @@ def _sum_complete(
             return None
         values.append(float(value))
     return round(sum(values), precision)
+
+
+def _range_complete(
+    batteries: tuple[RenogyHubBatteryState, ...],
+    field: str,
+    *,
+    precision: int,
+) -> _HubRange:
+    """Return min/max/spread only when every communicating battery has the field."""
+    if not batteries:
+        return _HubRange(None, None, None, None, None)
+
+    values: list[tuple[RenogyHubBatteryState, float]] = []
+    for battery in batteries:
+        value = getattr(battery, field)
+        if value is None:
+            return _HubRange(None, None, None, None, None)
+        values.append((battery, float(value)))
+
+    minimum_battery, minimum_value = min(values, key=lambda item: item[1])
+    maximum_battery, maximum_value = max(values, key=lambda item: item[1])
+    return _HubRange(
+        minimum=round(minimum_value, precision),
+        minimum_slave_id=minimum_battery.slave_id,
+        maximum=round(maximum_value, precision),
+        maximum_slave_id=maximum_battery.slave_id,
+        spread=round(maximum_value - minimum_value, precision),
+    )
 
 
 def _optional_float(value: Any) -> float | None:

--- a/custom_components/renogy/hub_sensor.py
+++ b/custom_components/renogy/hub_sensor.py
@@ -85,6 +85,13 @@ HUB_BANK_COUNT_KEYS = frozenset(
     {"communicating_battery_count", "discovered_battery_count"}
 )
 
+HUB_BANK_EXTREME_SLAVE_ID_KEYS = {
+    "battery_percentage_min": "battery_percentage_min_slave_id",
+    "battery_percentage_max": "battery_percentage_max_slave_id",
+    "battery_voltage_min": "battery_voltage_min_slave_id",
+    "battery_voltage_max": "battery_voltage_max_slave_id",
+}
+
 HUB_BANK_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="communicating_battery_count",
@@ -136,6 +143,72 @@ HUB_BANK_SENSORS: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+HUB_BANK_DIAGNOSTIC_SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="battery_percentage_min",
+        name="Minimum State of Charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_percentage_max",
+        name="Maximum State of Charge",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_percentage_spread",
+        name="SOC Spread",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_voltage_min",
+        name="Minimum Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_voltage_max",
+        name="Maximum Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_voltage_spread",
+        name="Voltage Spread",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
+    SensorEntityDescription(
+        key="battery_current_spread",
+        name="Current Spread",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+)
+
+
+def _bank_supports_diagnostics(bank: Any) -> bool:
+    """Return whether the bank state carries the Phase 2B diagnostic fields."""
+    return all(
+        hasattr(bank, description.key)
+        for description in HUB_BANK_DIAGNOSTIC_SENSORS
+    )
+
 
 def setup_hub_battery_sensors(
     config_entry: ConfigEntry,
@@ -169,12 +242,15 @@ def setup_hub_battery_sensors(
 
         if not bank_initialized and coordinator.hub_bank is not None:
             bank_initialized = True
+            bank_descriptions = HUB_BANK_SENSORS
+            if _bank_supports_diagnostics(coordinator.hub_bank):
+                bank_descriptions += HUB_BANK_DIAGNOSTIC_SENSORS
             new_entities.extend(
                 RenogyHubBankSensor(
                     coordinator=coordinator,
                     description=description,
                 )
-                for description in HUB_BANK_SENSORS
+                for description in bank_descriptions
             )
 
         if new_entities:
@@ -315,3 +391,20 @@ class RenogyHubBankSensor(PassiveBluetoothCoordinatorEntity, SensorEntity):
         if key in HUB_BANK_COUNT_KEYS:
             return int(value)
         return float(value)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Expose the battery producing a bank minimum or maximum."""
+        bank = self._bank
+        key = self.entity_description.key
+        if bank is None or key is None:
+            return {}
+
+        slave_id_key = HUB_BANK_EXTREME_SLAVE_ID_KEYS.get(key)
+        if slave_id_key is None:
+            return {}
+
+        slave_id = getattr(bank, slave_id_key, None)
+        if slave_id is None:
+            return {}
+        return {"slave_id": f"0x{int(slave_id):02X}"}

--- a/tests/test_hub_bank_diagnostics.py
+++ b/tests/test_hub_bank_diagnostics.py
@@ -1,0 +1,228 @@
+"""Tests for Communication Hub communicating-bank imbalance diagnostics."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+@dataclass
+class _FakeResult:
+    success: bool
+    batteries: list[Any]
+    error: Exception | None = None
+
+
+class _FakeHub:
+    def __init__(self, results: list[_FakeResult]) -> None:
+        self._results = list(results)
+
+    async def read_batteries(
+        self,
+        _device: Any,
+        *,
+        rediscover: bool = False,
+    ) -> _FakeResult:
+        del rediscover
+        return self._results.pop(0)
+
+
+def _battery(slave_id: int, **data: Any) -> Any:
+    return SimpleNamespace(slave_id=slave_id, parsed_data=data)
+
+
+def _install_integration_package() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    custom_components_path = str(repo_root / "custom_components")
+    renogy_path = str(repo_root / "custom_components" / "renogy")
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [custom_components_path]
+    sys.modules["custom_components"] = custom_components_pkg
+
+    renogy_pkg = types.ModuleType("custom_components.renogy")
+    renogy_pkg.__path__ = [renogy_path]
+    sys.modules["custom_components.renogy"] = renogy_pkg
+
+
+def _load_hub_module() -> Any:
+    _install_integration_package()
+    sys.modules.pop("custom_components.renogy.hub", None)
+    return importlib.import_module("custom_components.renogy.hub")
+
+
+def _manager(module: Any, results: list[_FakeResult]) -> Any:
+    fake_hub = _FakeHub(results)
+    return module.RenogyHubBatteryManager(
+        object(),
+        hub_factory=lambda _client: fake_hub,
+    )
+
+
+def test_hub_bank_builds_imbalance_diagnostics_from_hardware_values() -> None:
+    module = _load_hub_module()
+    manager = _manager(
+        module,
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=49.6,
+                        battery_current=-2.87,
+                        battery_power=-142.352,
+                        battery_remaining_capacity=45.695,
+                        battery_capacity=49.993,
+                        battery_percentage=91.4,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_voltage=49.7,
+                        battery_current=-1.53,
+                        battery_power=-76.041,
+                        battery_remaining_capacity=47.494,
+                        battery_capacity=49.993,
+                        battery_percentage=95.0,
+                    ),
+                    _battery(
+                        0x32,
+                        battery_voltage=49.7,
+                        battery_current=-1.87,
+                        battery_power=-92.939,
+                        battery_remaining_capacity=46.818,
+                        battery_capacity=49.993,
+                        battery_percentage=93.6,
+                    ),
+                    _battery(
+                        0x33,
+                        battery_voltage=49.7,
+                        battery_current=-0.82,
+                        battery_power=-40.754,
+                        battery_remaining_capacity=48.277,
+                        battery_capacity=49.995,
+                        battery_percentage=96.6,
+                    ),
+                ],
+            )
+        ],
+    )
+
+    assert asyncio.run(manager.async_update(object())) is True
+    bank = manager.bank
+    assert bank is not None
+
+    assert bank.battery_percentage_min == 91.4
+    assert bank.battery_percentage_min_slave_id == 0x30
+    assert bank.battery_percentage_max == 96.6
+    assert bank.battery_percentage_max_slave_id == 0x33
+    assert bank.battery_percentage_spread == 5.2
+
+    assert bank.battery_voltage_min == 49.6
+    assert bank.battery_voltage_min_slave_id == 0x30
+    assert bank.battery_voltage_max == 49.7
+    assert bank.battery_voltage_max_slave_id == 0x31
+    assert bank.battery_voltage_spread == 0.1
+
+    assert bank.battery_current_spread == 2.05
+
+
+def test_hub_bank_diagnostics_exclude_unavailable_batteries() -> None:
+    module = _load_hub_module()
+    manager = _manager(
+        module,
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=50.1,
+                        battery_current=1.2,
+                        battery_percentage=88.0,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_voltage=50.3,
+                        battery_current=2.0,
+                        battery_percentage=92.0,
+                    ),
+                ],
+            ),
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=50.2,
+                        battery_current=1.4,
+                        battery_percentage=89.0,
+                    )
+                ],
+                TimeoutError("battery timeout"),
+            ),
+        ],
+    )
+
+    async def _run() -> None:
+        assert await manager.async_update(object()) is True
+        assert await manager.async_update(object()) is True
+
+    asyncio.run(_run())
+
+    bank = manager.bank
+    assert bank is not None
+    assert bank.communicating_battery_count == 1
+    assert bank.discovered_battery_count == 2
+    assert bank.battery_percentage_min == 89.0
+    assert bank.battery_percentage_max == 89.0
+    assert bank.battery_percentage_spread == 0.0
+    assert bank.battery_percentage_min_slave_id == 0x30
+    assert bank.battery_percentage_max_slave_id == 0x30
+    assert bank.battery_voltage_spread == 0.0
+    assert bank.battery_current_spread == 0.0
+
+
+def test_hub_bank_diagnostics_require_complete_communicating_fields() -> None:
+    module = _load_hub_module()
+    manager = _manager(
+        module,
+        [
+            _FakeResult(
+                True,
+                [
+                    _battery(
+                        0x30,
+                        battery_voltage=50.1,
+                        battery_current=1.2,
+                        battery_percentage=88.0,
+                    ),
+                    _battery(
+                        0x31,
+                        battery_voltage=None,
+                        battery_current=None,
+                        battery_percentage=None,
+                    ),
+                ],
+            )
+        ],
+    )
+
+    asyncio.run(manager.async_update(object()))
+    bank = manager.bank
+    assert bank is not None
+    assert bank.battery_percentage_min is None
+    assert bank.battery_percentage_max is None
+    assert bank.battery_percentage_spread is None
+    assert bank.battery_percentage_min_slave_id is None
+    assert bank.battery_percentage_max_slave_id is None
+    assert bank.battery_voltage_min is None
+    assert bank.battery_voltage_max is None
+    assert bank.battery_voltage_spread is None
+    assert bank.battery_current_spread is None


### PR DESCRIPTION
## Summary

Extend the existing `Renogy Hub Communicating Bank` device with seven derived imbalance diagnostics. All values are computed in `renogy-ha` from the already-cached child-battery telemetry introduced by the Communication Hub support, so this adds no BLE or Modbus requests and does not change any existing device/entity identifiers.

## New bank sensors

- Minimum State of Charge
- Maximum State of Charge
- SOC Spread
- Minimum Voltage
- Maximum Voltage
- Voltage Spread
- Current Spread

For the four min/max sensors, `extra_state_attributes["slave_id"]` identifies the Hub battery producing the extreme, for example `0x30`.

## Semantics

- Only currently communicating (`available`) Hub batteries participate.
- Previously discovered but unavailable batteries are excluded, matching the Phase 2A communicating-bank aggregate behavior.
- A one-battery communicating bank reports min=max and a spread of `0`.
- If any communicating battery is missing the field required for a diagnostic, that diagnostic is unavailable rather than silently omitting the battery.
- Ties for min/max resolve deterministically to the lowest slave ID because Hub batteries are already ordered by slave ID.
- Current spread is `max(current) - min(current)`, so it remains meaningful across mixed charging/discharging values.

## Hardware-value expectations covered by tests

Using the four child-battery values previously validated on real hardware:

- SOC: 91.4% to 96.6% -> 5.2% spread (`0x30` min, `0x33` max)
- Voltage: 49.6 V to 49.7 V -> 0.1 V spread (`0x30` min; tied max resolves to `0x31`)
- Current: -2.87 A to -0.82 A -> 2.05 A spread

Tests also cover partial-bank operation and incomplete communicating telemetry.

## Compatibility

The original seven Phase 2A bank sensors and their unique IDs are unchanged. The bank state keeps the existing primary `as_dict()` payload stable; the new diagnostics are additional state fields consumed by the bank sensor layer.

## Transport impact

None. All diagnostics are HA-side derivations from existing cached Hub battery telemetry.