### PR TITLE
fix: scope device registry lookup to config entry

### DIFF
--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -251,8 +251,13 @@ async def update_device_registry(
             else device.device_type.capitalize()
         )
 
-        # Find the device in the registry using the domain and device address
-        device_entry = device_registry.async_get_device({(DOMAIN, device.address)})
+        # Scope identifiers to this config entry on HA 2026.8 and newer.
+        # Retain the legacy lookup for the supported HA 2026.3 minimum.
+        lookup = getattr(device_registry, "async_get_device_by_identifier", None)
+        if lookup is not None:
+            device_entry = lookup((DOMAIN, device.address), entry.entry_id)
+        else:
+            device_entry = device_registry.async_get_device({(DOMAIN, device.address)})
 
         if device_entry:
             # Update the device name

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -356,3 +356,61 @@ def test_async_shutdown_coordinator_times_out() -> None:
 
     coordinator.async_shutdown.assert_awaited_once()
     init_module.LOGGER.warning.assert_called_once()
+
+
+def test_registry_update_scopes_lookup_to_config_entry() -> None:
+    """Duplicate identifiers across entries must resolve to the owning entry."""
+    module, _ = _load_init_module()
+    registry = MagicMock()
+    module.async_get_device_registry.return_value = registry
+    entry = types.SimpleNamespace(entry_id="renogy-entry")
+    device = types.SimpleNamespace(
+        address="AA:BB", name="Controller", device_type="controller", parsed_data={}
+    )
+    registry.async_get_device_by_identifier.return_value = types.SimpleNamespace(
+        id="owned"
+    )
+
+    asyncio.run(module.update_device_registry(MagicMock(), entry, device))
+
+    registry.async_get_device_by_identifier.assert_called_once_with(
+        (module.DOMAIN, "AA:BB"), "renogy-entry"
+    )
+    registry.async_get_device.assert_not_called()
+    registry.async_update_device.assert_called_once_with(
+        "owned", name="Controller", model="Controller"
+    )
+
+
+def test_registry_update_supports_legacy_home_assistant() -> None:
+    """The supported HA minimum has no scoped lookup method."""
+    module, _ = _load_init_module()
+    registry = MagicMock(spec=["async_get_device", "async_update_device"])
+    module.async_get_device_registry.return_value = registry
+    registry.async_get_device.return_value = types.SimpleNamespace(id="legacy")
+    device = types.SimpleNamespace(
+        address="AA:BB", name="Controller", device_type="controller", parsed_data={}
+    )
+
+    asyncio.run(module.update_device_registry(MagicMock(), MagicMock(), device))
+
+    registry.async_get_device.assert_called_once_with({(module.DOMAIN, "AA:BB")})
+    registry.async_update_device.assert_called_once_with(
+        "legacy", name="Controller", model="Controller"
+    )
+
+
+def test_registry_update_does_not_fall_back_when_scoped_lookup_misses() -> None:
+    """A missing owned device must not update another entry's device."""
+    module, _ = _load_init_module()
+    registry = MagicMock()
+    module.async_get_device_registry.return_value = registry
+    registry.async_get_device_by_identifier.return_value = None
+    device = types.SimpleNamespace(
+        address="AA:BB", name="Controller", device_type="controller", parsed_data={}
+    )
+
+    asyncio.run(module.update_device_registry(MagicMock(), MagicMock(), device))
+
+    registry.async_get_device.assert_not_called()
+    registry.async_update_device.assert_not_called()


### PR DESCRIPTION
Use the config-entry-scoped device registry lookup when updating the controller name and model. This removes the deprecated `async_get_device` call on newer Home Assistant versions and avoids selecting a device owned by another config entry. Retain the legacy lookup when the new API is absent, preserving the advertised Home Assistant 2026.3 minimum. A scoped lookup miss never falls back to the ambiguous API.

Addresses the registry warning reported in https://github.com/IAmTheMitchell/renogy-ha/issues/221#issuecomment-5543565209. Home Assistant schedules removal of the old API for 2027.8.

Validation: Ruff format/lint, ty, all 170 tests, and `git diff --check` passed. Added coverage for scoped lookup, legacy compatibility, and a missing owned device. Independent review checked API signatures against HA 2026.3 and 2026.9 source and found no actionable issues.

Validation used the existing project environment through `uv run --no-sync`. Fresh macOS installation from the unchanged lockfile failed building PyObjC because `pkg_resources` was missing; a fresh install and live HA reload were not validated.
