### PR TITLE
fix: restore device names lost to passive Bluetooth scanning

### DIFF
--- a/custom_components/renogy/__init__.py
+++ b/custom_components/renogy/__init__.py
@@ -100,6 +100,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             non_shunt_connection_mode=non_shunt_connection_mode,
             max_failures=max_failures,
             unavailable_retry_interval=unavailable_retry_interval,
+            # The entry title is the name the device was discovered
+            # under, so it survives restarts even when no advertisement
+            # carries a local name.
+            device_name=entry.title,
             device_data_callback=device_data_callback,
             communication_hub_enabled=True,
             model_hint=model_hint,
@@ -115,6 +119,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             non_shunt_connection_mode=non_shunt_connection_mode,
             max_failures=max_failures,
             unavailable_retry_interval=unavailable_retry_interval,
+            # The entry title is the name the device was discovered
+            # under, so it survives restarts even when no advertisement
+            # carries a local name.
+            device_name=entry.title,
             device_data_callback=device_data_callback,
             model_hint=model_hint,
         )
@@ -235,7 +243,7 @@ async def _handle_device_update(
 
         # Update the device name in the Home Assistant device registry
         # This will ensure the device name is updated in the UI
-        if has_real_device_name(device.name):
+        if has_real_device_name(device.name, device.address):
             await update_device_registry(hass, entry, device)
 
 

--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -116,6 +116,7 @@ class RenogyActiveBluetoothCoordinator(
         max_failures: int = DEFAULT_MAX_FAILURES,
         unavailable_retry_interval: int = DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
         model_hint: str | None = None,
+        device_name: str | None = None,
         device_data_callback: Callable[[RenogyBLEDevice], Awaitable[None]]
         | None = None,
     ):
@@ -130,6 +131,14 @@ class RenogyActiveBluetoothCoordinator(
             connectable=True,
         )
         self.device: RenogyBLEDevice | None = None
+        # The name resolved when the device was added, kept across restarts by
+        # the config entry. Advertisements are an unreliable source for it: the
+        # local name rides in the scan response only, so it is absent under
+        # passive scanning and merely intermittent under active scanning, which
+        # connection attempts keep suspending.
+        self.configured_name = (
+            device_name if has_real_device_name(device_name, address) else None
+        )
         self.scan_interval = scan_interval
         self.shunt_connection_mode = shunt_connection_mode
         self.non_shunt_connection_mode = non_shunt_connection_mode
@@ -430,6 +439,34 @@ class RenogyActiveBluetoothCoordinator(
         if callable(close_client):
             await close_client()
 
+    def _resolve_name(self, service_info: BluetoothServiceInfoBleak) -> str | None:
+        """Best available name for the device, or None if we have none.
+
+        Three sources, in descending order of freshness:
+
+        1. the advertisement. A Renogy device puts its local name in the scan
+           response only, so this is empty under passive scanning and merely
+           intermittent under active scanning, which connection attempts keep
+           suspending;
+        2. BlueZ, via ``BLEDevice.name`` (its ``Alias``/``Name`` property).
+           BlueZ persists this in ``/var/lib/bluetooth/<adapter>/cache/`` and
+           serves it whether or not anything is scanning, so it is the source
+           that actually works on a passive-only host. It is empty for a short
+           while after a restart, until BlueZ re-materialises the device;
+        3. the name the device was added under, kept in the config entry.
+
+        Anything that is really just a BD address is not a name -- see
+        has_real_device_name().
+        """
+        for candidate in (
+            service_info.name,
+            getattr(service_info.device, "name", None),
+            self.configured_name,
+        ):
+            if has_real_device_name(candidate, service_info.address):
+                return clean_device_name(candidate)
+        return None
+
     def _update_device_from_service_info(
         self, service_info: BluetoothServiceInfoBleak
     ) -> RenogyBLEDevice:
@@ -438,10 +475,12 @@ class RenogyActiveBluetoothCoordinator(
         if not manufacturer_data and self.device is not None:
             # Some follow-up advertisements omit manufacturer data entirely.
             manufacturer_data = self.device.manufacturer_data
+        resolved_name = self._resolve_name(service_info)
         detected_type = detect_device_type_from_ble_name(
-            service_info.name,
+            resolved_name,
             self.device_type,
             manufacturer_data=manufacturer_data,
+            address=service_info.address,
         )
         if self.device_type != detected_type:
             self.logger.debug(
@@ -466,19 +505,35 @@ class RenogyActiveBluetoothCoordinator(
                 unavailable_retry_interval=self.unavailable_retry_interval,
                 model_hint=self.model_hint,
             )
+            # RenogyBLEDevice takes its name from the BLEDevice, which carries
+            # the address when no advertisement has supplied a local name. Put
+            # the remembered name back so battery variant detection -- which
+            # matches on the name prefix -- works on the very first poll after
+            # a restart instead of failing until a scan response happens to
+            # land. RenogyBLEDevice.battery_variant is re-derived from the name
+            # on each read when it is still None, so fixing the name is enough.
+            if resolved_name and not has_real_device_name(
+                self.device.name, self.address
+            ):
+                self.device.name = resolved_name
         else:
             old_name = self.device.name
             self.device.ble_device = service_info.device
             self.device.manufacturer_data = dict(manufacturer_data)
-            if has_real_device_name(service_info.name):
-                cleaned_name = clean_device_name(service_info.name)
-                if old_name != cleaned_name:
-                    self.device.name = cleaned_name
-                    self.logger.debug(
-                        "Updated device name from '%s' to '%s'",
-                        old_name,
-                        cleaned_name,
-                    )
+            # Only fill in a name we do not have. A completed read replaces
+            # device.name with the name the hardware reports for itself
+            # (renogy_ble sets it from the device_name register, e.g.
+            # "RBT12500LFP-SHBT"), which is what the device registry shows and
+            # is better than anything on air. Overwriting it from every
+            # advertisement would flip the name back and forth for as long as
+            # the integration runs.
+            if resolved_name and not has_real_device_name(old_name, self.address):
+                self.device.name = resolved_name
+                self.logger.debug(
+                    "Updated device name from '%s' to '%s'",
+                    old_name,
+                    resolved_name,
+                )
 
             self.device.rssi = (
                 service_info.advertisement.rssi

--- a/custom_components/renogy/config_flow.py
+++ b/custom_components/renogy/config_flow.py
@@ -76,7 +76,7 @@ CONFIG_SCHEMA = vol.Schema({**DEVICE_TYPE_SCHEMA, **SCAN_INTERVAL_SCHEMA})
 
 def _display_name_for_discovery(discovery_info: BluetoothServiceInfoBleak) -> str:
     """Return a stable display name for a discovered BLE device."""
-    if has_real_device_name(discovery_info.name):
+    if has_real_device_name(discovery_info.name, discovery_info.address):
         return discovery_info.name
 
     return UNKNOWN_DEVICE_NAME
@@ -89,6 +89,7 @@ def _detect_device_type_for_discovery(discovery_info: BluetoothServiceInfoBleak)
         discovery_info.name,
         DEFAULT_DEVICE_TYPE,
         manufacturer_data=manufacturer_data,
+        address=discovery_info.address,
     )
 
 
@@ -201,6 +202,7 @@ class RenogyConfigFlow(ConfigFlow, domain=DOMAIN):
         return is_supported_renogy_ble_name(
             discovery_info.name,
             manufacturer_data=manufacturer_data,
+            address=discovery_info.address,
         )
 
     async def async_step_bluetooth(

--- a/custom_components/renogy/device_name.py
+++ b/custom_components/renogy/device_name.py
@@ -40,11 +40,56 @@ SUPPORTED_BLE_NAME_PREFIXES: tuple[str, ...] = (
 )
 
 
-def has_real_device_name(device_name: str | None) -> bool:
-    """Return True when the provided name is usable and not a placeholder."""
+def has_real_device_name(device_name: str | None, address: str | None = None) -> bool:
+    """Return True when the provided name is usable and not a placeholder.
+
+    Pass ``address`` whenever the caller has it. Without it the
+    address-placeholder check below cannot run, because deciding whether a name
+    is really an address requires the address to compare against. Every call
+    site in this integration passes one.
+    """
     if not isinstance(device_name, str):
         return False
-    return bool(device_name) and not device_name.startswith(UNKNOWN_DEVICE_NAME_PREFIX)
+    if not device_name or device_name.startswith(UNKNOWN_DEVICE_NAME_PREFIX):
+        return False
+    return not is_address_placeholder(device_name, address)
+
+
+def is_address_placeholder(device_name: str | None, address: str | None) -> bool:
+    """Return True when the "name" is really the device's own address.
+
+    A Renogy device only sends its local name in the scan response, so under
+    passive scanning -- which is what Home Assistant's default ``auto`` mode
+    picks on any adapter that supports it -- no advertisement ever carries one.
+    The stack below us then falls back to the address, and that string is what
+    reaches this integration as a name. Treating it as a real name is worse
+    than having none: it overwrites a good cached name, and battery variant
+    detection keys on the ``RNGPRO``/``RBT`` prefix, so it fails with the
+    confusing "Unable to determine Renogy battery variant for
+    14:9C:EF:03:68:81".
+
+    Recognise it the way the layers below already do -- by comparing against
+    the address, never by matching a pattern. Two fallbacks exist, one per
+    layer:
+
+    * ``habluetooth`` builds the service info name as ``local_name or
+      device.name or device.address`` and undoes it by testing
+      ``name == address`` (``habluetooth/models.py``, 6.8.0). That is the
+      fallback this integration actually sees.
+    * BlueZ generates an ``Alias`` of the address with ``:`` replaced by ``-``.
+      ``bleak`` normalises that one to ``None`` before it reaches us
+      (``bleak/backends/bluezdbus/scanner.py``, 3.0.2), so it should not get
+      this far -- it is checked anyway because the cost is one comparison.
+
+    A pattern cannot do this job: ``BLEDevice.address`` is a **UUID on macOS**,
+    not a BD address, so no MAC-shaped regex would recognise the placeholder
+    there. Comparing against the address is correct on every platform.
+    """
+    if not isinstance(device_name, str) or not address:
+        return False
+    name = device_name.strip().casefold()
+    resolved = address.strip().casefold()
+    return name == resolved or name == resolved.replace(":", "-")
 
 
 def expected_prefixes_for_device_type(device_type: str) -> tuple[str, ...]:
@@ -52,9 +97,13 @@ def expected_prefixes_for_device_type(device_type: str) -> tuple[str, ...]:
     return DEVICE_NAME_PREFIXES_BY_TYPE.get(device_type, (RENOGY_BT_PREFIX,))
 
 
-def is_device_name_ready(device_name: str | None, device_type: str) -> bool:
+def is_device_name_ready(
+    device_name: str | None, device_type: str, address: str | None = None
+) -> bool:
     """Return True when a name is present and matches the expected prefix."""
-    if not isinstance(device_name, str) or not has_real_device_name(device_name):
+    if not isinstance(device_name, str) or not has_real_device_name(
+        device_name, address
+    ):
         return False
     if device_type == DeviceType.BATTERY.value and _is_legacy_battery_name(device_name):
         return True
@@ -64,23 +113,26 @@ def is_device_name_ready(device_name: str | None, device_type: str) -> bool:
 def is_supported_renogy_ble_name(
     device_name: str | None,
     manufacturer_data: dict[int, bytes] | None = None,
+    address: str | None = None,
 ) -> bool:
     """Return True for BLE advertisements from supported Renogy devices."""
     return detect_device_type_from_ble_name(
         device_name,
         manufacturer_data=manufacturer_data,
-    ) != DEFAULT_DEVICE_TYPE or _is_supported_default_type_name(device_name)
+        address=address,
+    ) != DEFAULT_DEVICE_TYPE or _is_supported_default_type_name(device_name, address)
 
 
 def detect_device_type_from_ble_name(
     device_name: str | None,
     default_device_type: str = DEFAULT_DEVICE_TYPE,
     manufacturer_data: dict[int, bytes] | None = None,
+    address: str | None = None,
 ) -> str:
     """Infer the device type from a BLE name, with a provided default fallback."""
     manufacturer_data = manufacturer_data or {}
 
-    if isinstance(device_name, str) and has_real_device_name(device_name):
+    if isinstance(device_name, str) and has_real_device_name(device_name, address):
         if device_name.startswith(
             (RENOGY_INVERTER_PREFIX, RENOGY_REGO_INVERTER_PREFIX)
         ):
@@ -127,9 +179,13 @@ def _is_legacy_battery_name(device_name: str) -> bool:
     return any(marker in suffix for marker in BATTERY_LEGACY_NAME_MARKERS)
 
 
-def _is_supported_default_type_name(device_name: str | None) -> bool:
+def _is_supported_default_type_name(
+    device_name: str | None, address: str | None = None
+) -> bool:
     """Return True for supported names that intentionally map to controller/DCC."""
-    if not isinstance(device_name, str) or not has_real_device_name(device_name):
+    if not isinstance(device_name, str) or not has_real_device_name(
+        device_name, address
+    ):
         return False
 
     return any(device_name.startswith(prefix) for prefix in SUPPORTED_BLE_NAME_PREFIXES)

--- a/custom_components/renogy/switch.py
+++ b/custom_components/renogy/switch.py
@@ -61,12 +61,12 @@ async def async_setup_entry(
         return
 
     if not coordinator.device or not is_device_name_ready(
-        coordinator.device.name, device_type
+        coordinator.device.name, device_type, coordinator.device.address
     ):
         LOGGER.debug("Creating switches without waiting for a resolved device name")
 
     device = coordinator.device
-    if device and not is_device_name_ready(device.name, device_type):
+    if device and not is_device_name_ready(device.name, device_type, device.address):
         device = None
 
     async_add_entities([RenogyLoadSwitch(coordinator, device, device_type)])

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -1400,3 +1400,152 @@ def test_model_mismatch_silent_when_type_matches_or_model_unknown():
     logger.warning.reset_mock()
     coordinator._warn_if_model_mismatch()
     logger.warning.assert_not_called()
+
+
+def test_nameless_advertisement_falls_back_to_the_configured_name() -> None:
+    """A restart with no local name on air must still identify the battery.
+
+    The local name rides in the scan response only, so a Pi's built-in adapter
+    under Home Assistant's default `auto` (== passive) scanning never sees one,
+    and HA labels the advertisement with its address. Before this fallback the
+    address became the device name, `detect_battery_variant()` found no
+    RNGPRO/RBT prefix, and every poll failed with "Unable to determine Renogy
+    battery variant" until a scan response happened to land.
+    """
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="14:9C:EF:03:68:81",
+        scan_interval=30,
+        device_type="battery",
+        device_name="RNGPRO125BAT-EF036881",
+    )
+    # What HA hands over when nothing has supplied a local name.
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81",
+        name="14:9C:EF:03:68:81",
+        rssi=-36,
+    )
+
+    device = coordinator._update_device_from_service_info(service_info)
+
+    assert device.name == "RNGPRO125BAT-EF036881"
+
+
+def test_a_real_advertised_name_still_wins() -> None:
+    """The fallback must not pin a stale name when the device does send one."""
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="14:9C:EF:03:68:81",
+        scan_interval=30,
+        device_type="battery",
+        device_name="RNGPRO125BAT-OLDNAME",
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81",
+        name="RNGPRO125BAT-EF036881",
+        rssi=-36,
+    )
+
+    device = coordinator._update_device_from_service_info(service_info)
+
+    assert device.name == "RNGPRO125BAT-EF036881"
+
+
+def test_bluez_cached_name_beats_a_nameless_advertisement() -> None:
+    """BlueZ is the source that works on a passive-only host.
+
+    It keeps the name in /var/lib/bluetooth/<adapter>/cache/ and serves it as
+    Device1.Alias whether or not anything is scanning, so bleak's
+    BLEDevice.name has it even when the advertisement does not. The
+    integration already receives that BLEDevice; it just was not consulted.
+    """
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="14:9C:EF:03:68:81",
+        scan_interval=30,
+        device_type="battery",
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81",
+        name="14:9C:EF:03:68:81",
+        rssi=-36,
+    )
+    service_info.device.name = "RNGPRO125BAT-EF036881"
+
+    device = coordinator._update_device_from_service_info(service_info)
+
+    assert device.name == "RNGPRO125BAT-EF036881"
+    # No configured name was supplied, so this came from BlueZ alone.
+    assert coordinator.configured_name is None
+
+
+def test_bluez_cached_name_rescues_a_device_already_holding_its_address() -> None:
+    """The update path is where the address actually has to be displaced.
+
+    On a passive-only host the first advertisements carry no name at all, so
+    the device ends up holding its own address. BlueZ re-materialises the
+    cached name a moment later, and the update path -- not just construction --
+    has to pick it up, or the address stays until a restart.
+    """
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="14:9C:EF:03:68:81",
+        scan_interval=30,
+        device_type="battery",
+    )
+    # Nothing knows a name yet: the advertisement has none and BlueZ has not
+    # re-materialised the device, so every source is the address.
+    nameless = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81", name="14:9C:EF:03:68:81", rssi=-36
+    )
+    device = coordinator._update_device_from_service_info(nameless)
+    assert not ble_module.has_real_device_name(device.name, "14:9C:EF:03:68:81")
+
+    # BlueZ now serves the cached Alias; the advertisement is still nameless.
+    cached = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81", name="14:9C:EF:03:68:81", rssi=-40
+    )
+    cached.device.name = "RNGPRO125BAT-EF036881"
+    device = coordinator._update_device_from_service_info(cached)
+
+    assert device.name == "RNGPRO125BAT-EF036881"
+
+
+def test_a_name_read_from_the_device_is_not_overwritten() -> None:
+    """A completed read renames the device to what the hardware calls itself.
+
+    renogy_ble sets device.name from the device_name register once a read
+    succeeds -- "RBT12500LFP-SHBT" for this battery, which is what the device
+    registry shows. Re-applying the BLE name on every advertisement would flip
+    the registry name back and forth forever.
+    """
+    ble_module = _load_ble_module()
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="14:9C:EF:03:68:81",
+        scan_interval=30,
+        device_type="battery",
+        device_name="RNGPRO125BAT-EF036881",
+    )
+    first = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81", name="RNGPRO125BAT-EF036881", rssi=-36
+    )
+    device = coordinator._update_device_from_service_info(first)
+    # What a successful battery read does.
+    device.name = "RBT12500LFP-SHBT"
+
+    later = ble_module.BluetoothServiceInfoBleak(
+        address="14:9C:EF:03:68:81", name="RNGPRO125BAT-EF036881", rssi=-40
+    )
+    device = coordinator._update_device_from_service_info(later)
+
+    assert device.name == "RBT12500LFP-SHBT"

--- a/tests/test_device_name.py
+++ b/tests/test_device_name.py
@@ -166,3 +166,55 @@ def test_btric_inverter_name_ready():
     assert device_name_module.is_device_name_ready(
         "BTRIC130000029", const_module.DeviceType.INVERTER.value
     )
+
+
+def test_bare_address_is_not_a_real_name() -> None:
+    """A BD address reaching us as a "name" must not be trusted.
+
+    Observed on a Pi with only its built-in adapter: Home Assistant's default
+    ``auto`` scanning mode resolves to passive, no advertisement then carries a
+    local name, and HA names each one after its address. That string was
+    accepted as real, overwrote the cached name, and battery variant detection
+    -- which matches the RNGPRO/RBT prefix -- failed with
+    "Unable to determine Renogy battery variant for 14:9C:EF:03:68:81".
+    """
+    device_name_module = _load_device_name_module()
+
+    # The habluetooth fallback: name is the address, verbatim.
+    assert not device_name_module.has_real_device_name(
+        "14:9C:EF:03:68:81", "14:9C:EF:03:68:81"
+    )
+    # Case must not matter -- BlueZ upper-cases, some backends do not.
+    assert not device_name_module.has_real_device_name(
+        "c4:d3:6a:8c:b5:38", "C4:D3:6A:8C:B5:38"
+    )
+    # The BlueZ Alias fallback: address with ":" replaced by "-". bleak
+    # normalises this away before it reaches us; checked anyway.
+    assert not device_name_module.has_real_device_name(
+        "C4-D3-6A-8C-B5-38", "C4:D3:6A:8C:B5:38"
+    )
+    assert not device_name_module.has_real_device_name(
+        "  14:9C:EF:03:68:81  ", "14:9C:EF:03:68:81"
+    )
+
+
+def test_a_macos_uuid_address_is_not_a_real_name() -> None:
+    """BLEDevice.address is a UUID on macOS, so no MAC-shaped pattern can spot
+    the placeholder there. Comparing against the address does."""
+    device_name_module = _load_device_name_module()
+
+    uuid = "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+    assert not device_name_module.has_real_device_name(uuid, uuid)
+
+
+def test_real_names_still_pass() -> None:
+    """The tightening must not reject anything that is actually a name."""
+    device_name_module = _load_device_name_module()
+
+    address = "14:9C:EF:03:68:81"
+    assert device_name_module.has_real_device_name("RNGPRO125BAT-EF036881", address)
+    assert device_name_module.has_real_device_name("BT-TH-6A8CB538", address)
+    # A name that merely looks address-shaped is still a name: only the
+    # device's own address is a placeholder.
+    assert device_name_module.has_real_device_name("C4:D3:6A:8C:B5:38", address)
+    assert device_name_module.has_real_device_name("14:9C:EF")


### PR DESCRIPTION
## Who this affects

Anyone whose Home Assistant host does its Bluetooth scanning **passively** — which is the default on most hosts with a built-in adapter, because HA's `auto` scanning mode resolves to passive on any adapter that supports it.

A Renogy device sends its local name in the **scan response** only. Passive scanning never sends `SCAN_REQ`, so no advertisement ever carries a name. Home Assistant falls back to labelling the advertisement with the device address, and that string arrives here as `service_info.name`.

Measured with `btmon` on an affected host: 45 s of scanning, 534 advertising reports, all `ADV_IND`, not one carrying a name, and no scan response at all even with active scanning configured — connection attempts keep suspending the scan.

## The bug

`has_real_device_name()` only rejected the literal `"Unknown"` placeholder, so the address was accepted as a real name and written over the cached one.

For a controller this is merely cosmetic — its command table is keyed on the configured device type. For a **battery** it is fatal: the protocol variant is resolved from the name prefix, so every poll failed with

```
Unable to determine Renogy battery variant for 14:9C:EF:03:68:81
```

until three failures marked the device unavailable.

## The fix

Recognise the placeholder the way the layers below already do — by **comparing against the address**, not by matching a pattern:

- `habluetooth` builds the name as `local_name or device.name or device.address` and undoes it with `name == address`;
- `bleak` normalises BlueZ's `Alias` of the address with `:` replaced by `-` to `None`.

Both are checked. A pattern cannot do this job: `BLEDevice.address` is a UUID on macOS, so no MAC-shaped regex would recognise the placeholder there. `has_real_device_name()` therefore takes the address to compare against, and every call site passes one.

The name is then resolved from the first source that has one:

1. the advertisement, when it carries a name;
2. **BlueZ, via `BLEDevice.name`** — BlueZ persists the name in `/var/lib/bluetooth/<adapter>/cache/` and serves it as `Device1.Alias` whether or not anything is scanning, so this is the source that works on a passive-only host. The integration already receives that `BLEDevice` and used it when constructing the device, but not when updating it;
3. the name the device was added under, from the config entry, for the window after a restart where BlueZ has not yet re-materialised the device.

`RenogyBLEDevice.battery_variant` is re-derived from the name on every read while it is still `None`, so restoring the name is enough to fix the read.

## Testing

New tests in `tests/test_ble.py` and `tests/test_device_name.py` cover the address-as-name placeholder in both spellings, the BlueZ and config-entry fallbacks, and the battery-variant recovery. Full suite: 175 passed, `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYcUjtrDQoXeRrjQRKYqUW
