### PR TITLE
fix: carry model and device_id across polls that could not read them

### DIFF
--- a/custom_components/renogy/ble.py
+++ b/custom_components/renogy/ble.py
@@ -42,6 +42,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SHUNT_CONNECTION_MODE,
     DEFAULT_UNAVAILABLE_RETRY_INTERVAL,
+    STATIC_DEVICE_INFO_KEYS,
     DeviceType,
     NonShuntConnectionMode,
     ShuntConnectionMode,
@@ -970,13 +971,31 @@ class RenogyActiveBluetoothCoordinator(
 
                 # Update coordinator data if successful
                 if success and device.parsed_data:
-                    self.data = dict(device.parsed_data)
+                    self.data = self._merge_static_device_info(dict(device.parsed_data))
                     self.logger.debug("Updated coordinator data: %s", self.data)
                     self._warn_if_model_mismatch()
 
                 return success
             finally:
                 self._connection_in_progress = False
+
+    def _merge_static_device_info(self, fresh: dict[str, Any]) -> dict[str, Any]:
+        """Carry static device-info keys forward when a poll could not read them.
+
+        renogy-ble clears the device's parsed data at the start of every poll and
+        skips any register section that times out. The BT-TH module answers the
+        device-info registers far less reliably than the measurement registers, so
+        a successful poll frequently arrives without ``model`` or ``device_id``.
+        Replacing the coordinator data wholesale then flips those diagnostic
+        sensors to unknown for values that never change. Only the keys listed in
+        STATIC_DEVICE_INFO_KEYS are carried; a measurement missing from a poll is
+        left missing so a stale reading is never reported as current.
+        """
+        previous = self.data if isinstance(self.data, dict) else {}
+        for key in STATIC_DEVICE_INFO_KEYS:
+            if key not in fresh and key in previous:
+                fresh[key] = previous[key]
+        return fresh
 
     def _warn_if_model_mismatch(self) -> None:
         """Warn once when the reported model implies a different device type.

--- a/custom_components/renogy/const.py
+++ b/custom_components/renogy/const.py
@@ -149,3 +149,12 @@ DCC_MAX_CURRENT_OPTIONS = [10, 20, 30, 40, 50, 60]
 
 # Mapping from amps to centiamps for writing
 DCC_MAX_CURRENT_TO_DEVICE = {amp: amp * 100 for amp in DCC_MAX_CURRENT_OPTIONS}
+
+# Keys that describe the device rather than measure it. They come from the low
+# device-info registers (12 and 26 on a controller), which the BT-TH module
+# answers unreliably, and renogy-ble clears its parsed data before every poll.
+# The coordinator carries these forward from the previous poll when a fresh poll
+# did not manage to read them, so a value that never changes does not flip to
+# unknown every time one register read times out. Measurements are never
+# carried: a stale reading presented as current is worse than an unknown.
+STATIC_DEVICE_INFO_KEYS: tuple[str, ...] = ("model", "device_id")

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -1400,3 +1400,87 @@ def test_model_mismatch_silent_when_type_matches_or_model_unknown():
     logger.warning.reset_mock()
     coordinator._warn_if_model_mismatch()
     logger.warning.assert_not_called()
+
+
+def _coordinator_with_previous_poll(ble_module, previous: dict):
+    """Build a controller coordinator that already holds one successful poll."""
+    coordinator = ble_module.RenogyActiveBluetoothCoordinator(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        address="AA:BB:CC:DD:EE:FF",
+        scan_interval=30,
+        device_type="controller",
+        non_shunt_connection_mode="persistent_session",
+    )
+    service_info = ble_module.BluetoothServiceInfoBleak(
+        address="AA:BB:CC:DD:EE:FF",
+        name="BT-TH-12345",
+        rssi=-60,
+    )
+    coordinator._update_device_from_service_info(service_info)
+    coordinator._ble_client.read_device = AsyncMock(
+        return_value=MagicMock(success=True, error=None)
+    )
+    coordinator.data = dict(previous)
+    return coordinator
+
+
+def test_static_device_info_survives_a_poll_that_could_not_read_it():
+    """The BT-TH module answers the device-info registers (12, 26) unreliably.
+
+    renogy-ble clears its parsed data at the start of every poll and skips any register
+    section that times out, so a poll where only the measurement registers answered
+    arrives here with no ``model`` and no ``device_id``. Replacing the coordinator's
+    data wholesale then flips both diagnostic sensors to ``unknown`` on every such poll
+    -- observed 209 times in 48 hours on a Rover -- for values that never change.
+    """
+    ble_module = _load_ble_module()
+    coordinator = _coordinator_with_previous_poll(
+        ble_module,
+        {"model": "RNG-CTRL-RVR", "device_id": 1, "battery_voltage": 13.4},
+    )
+    # This poll read the measurement registers but not the device-info ones.
+    coordinator.device.parsed_data = {"battery_voltage": 13.6}
+
+    assert asyncio.run(coordinator._read_device_data(None)) is True
+
+    assert coordinator.data["model"] == "RNG-CTRL-RVR"
+    assert coordinator.data["device_id"] == 1
+    assert coordinator.data["battery_voltage"] == 13.6
+
+
+def test_fresh_static_device_info_replaces_the_carried_value():
+    """A poll that DID read the device-info registers must win over the carried copy."""
+    ble_module = _load_ble_module()
+    coordinator = _coordinator_with_previous_poll(
+        ble_module, {"model": "STALE", "device_id": 9, "battery_voltage": 13.4}
+    )
+    coordinator.device.parsed_data = {
+        "model": "RNG-CTRL-RVR",
+        "device_id": 1,
+        "battery_voltage": 13.6,
+    }
+
+    assert asyncio.run(coordinator._read_device_data(None)) is True
+
+    assert coordinator.data["model"] == "RNG-CTRL-RVR"
+    assert coordinator.data["device_id"] == 1
+
+
+def test_missing_measurements_are_not_carried_forward():
+    """Only the static keys are carried. A measurement absent from a poll stays absent.
+
+    Carrying a reading like ``pv_power`` from a previous poll would present a stale
+    number as current, which is worse than reporting ``unknown``.
+    """
+    ble_module = _load_ble_module()
+    coordinator = _coordinator_with_previous_poll(
+        ble_module,
+        {"model": "RNG-CTRL-RVR", "device_id": 1, "pv_power": 22.0},
+    )
+    coordinator.device.parsed_data = {"battery_voltage": 13.6}
+
+    assert asyncio.run(coordinator._read_device_data(None)) is True
+
+    assert "pv_power" not in coordinator.data
+    assert coordinator.data["model"] == "RNG-CTRL-RVR"


### PR DESCRIPTION
## What

The coordinator now carries `model` and `device_id` forward from the previous poll when a fresh poll did not manage to read them. Only those two keys are carried; a measurement missing from a poll stays missing.

## Why

`renogy-ble` clears the device's parsed data at the start of every poll (`ble.py:585` in 2.6.1) and `continue`s past any register section that times out. On a Rover behind a BT-TH-D730C3CE the device-info registers (12 = model, 26 = device ID) answer far less reliably than the measurement registers (256+), so a *successful* poll very often arrives with all the measurements and no `model`/`device_id`. `self.data = dict(device.parsed_data)` then drops them and both diagnostic sensors flip to `unknown`.

Measured over 48 hours on that Rover, from the recorder:

| sensor | register | state changes | of which `unknown` |
|---|---|---|---|
| model | 12 | 419 | 209 |
| device_id | 26 | 47 | 23 |
| battery_voltage | 256+ | 53 | 3 |
| pv_voltage | 256+ | 653 | 3 |
| charging_status | 288 | 11 | 3 |

The three `unknown`s on the measurement sensors were genuine BLE outages (ESPHome proxy at "0 scanners registered"). The 209 on `model` were not — it is a constant string being rewritten to the recorder every other minute.

## Why only the static keys

Carrying *everything* forward would silently present a stale `pv_power` as current whenever a poll dropped it, which is worse than reporting `unknown`. `STATIC_DEVICE_INFO_KEYS` is deliberately just the values that describe the device rather than measure it. A poll that does read the device-info registers still wins over the carried copy, so a genuinely changed value is never masked.

## Tests

Three new tests in `tests/test_ble.py`, mirroring `test_read_device_data_uses_cached_device_without_service_info`:

- a poll without `model`/`device_id` keeps the previous values and takes the fresh measurement
- a poll *with* them replaces the carried copy
- a missing measurement is **not** carried

`uv run pytest` 170 passed; `ruff check` and `ruff format --check` clean. `uv.lock` untouched.
